### PR TITLE
BREAK: add option to use decay LS-couplings

### DIFF
--- a/docs/jpsi2ksp.ipynb
+++ b/docs/jpsi2ksp.ipynb
@@ -499,7 +499,7 @@
    },
    "outputs": [],
    "source": [
-    "model_builder = DalitzPlotDecompositionBuilder(DECAY, use_helicity_couplings=False)\n",
+    "model_builder = DalitzPlotDecompositionBuilder(DECAY, min_ls=False)\n",
     "for chain in model_builder.decay.chains:\n",
     "    model_builder.dynamics_choices.register_builder(\n",
     "        chain, formulate_breit_wigner_with_ff\n",

--- a/docs/lc2pkpi.ipynb
+++ b/docs/lc2pkpi.ipynb
@@ -336,9 +336,7 @@
    },
    "outputs": [],
    "source": [
-    "model_builder = DalitzPlotDecompositionBuilder(\n",
-    "    DECAY, use_helicity_couplings=(False, True)\n",
-    ")\n",
+    "model_builder = DalitzPlotDecompositionBuilder(DECAY, min_ls=(False, True))\n",
     "for chain in model_builder.decay.chains:\n",
     "    model_builder.dynamics_choices.register_builder(chain, formulate_breit_wigner)\n",
     "model = model_builder.formulate(reference_subsystem=1)\n",

--- a/src/ampform_dpd/__init__.py
+++ b/src/ampform_dpd/__init__.py
@@ -49,13 +49,13 @@ class DalitzPlotDecompositionBuilder:
     def __init__(
         self,
         decay: ThreeBodyDecay,
-        use_helicity_couplings: tuple[bool, bool] | bool = True,
+        min_ls: tuple[bool, bool] | bool = True,
     ) -> None:
         """Amplitude builder for the helicity formalism with Dalitz-plot decomposition.
 
         Args:
             decay: The `.ThreeBodyDecay` over which to formulate the amplitude model.
-            use_helicity_couplings: Use helicity couplings instead of
+            min_ls: Use helicity couplings instead of
                 :math:`LS`-couplings. If setting this boolean with a `tuple`, the first
                 element of the `tuple` defines whether to use helicity couplings on the
                 **production** `.IsobarNode` and the second configures the **decay**
@@ -63,22 +63,18 @@ class DalitzPlotDecompositionBuilder:
         """
         self.decay = decay
         self.dynamics_choices = DynamicsConfigurator(decay)
-        if isinstance(use_helicity_couplings, bool):
-            self.use_production_helicity_couplings = use_helicity_couplings
-            self.use_decay_helicity_couplings = use_helicity_couplings
-        elif (
-            isinstance(use_helicity_couplings, tuple)
-            and len(use_helicity_couplings) == 2
-        ):
+        if isinstance(min_ls, bool):
+            self.use_production_helicity_couplings = min_ls
+            self.use_decay_helicity_couplings = min_ls
+        elif isinstance(min_ls, tuple) and len(min_ls) == 2:
             (
                 self.use_production_helicity_couplings,
                 self.use_decay_helicity_couplings,
-            ) = use_helicity_couplings
+            ) = min_ls
         else:
             raise NotImplementedError(
-                "Cannot configure helicity couplings with a"
-                f" {type(use_helicity_couplings).__name__}",
-                use_helicity_couplings,
+                f"Cannot configure helicity couplings with a {type(min_ls).__name__}",
+                min_ls,
             )
 
     def formulate(


### PR DESCRIPTION
**Breaking change**: the `min_ls` argument of the `DalitzPlotDecompositionBuilder` has been renamed to `use_helicity_couplings`. If a `tuple` of two booleans: the first configures the production node for the resonance, the second configures the decay node (if giving a `bool` instead of a `tuple`, both nodes are set). This is a new feature.

Note that the equivalent of the previous `min_ls=True` is `use_helicity_couplings=True` and `min_ls=False` is `use_helicity_couplings=(True, False)`.

### This PR
![decay-LS-couplings](https://user-images.githubusercontent.com/29308176/206438496-e93ef936-5ee8-4df7-939e-acc0f0701eec.svg)
![image](https://user-images.githubusercontent.com/29308176/206438882-9cf6b686-5ef8-48ea-9e5d-7cd77e8a9c22.png)


### Main branch (86011d9)

![image](https://user-images.githubusercontent.com/29308176/206438401-a1165ad9-d9f8-4246-bdb8-694b3742b899.png)
![main](https://user-images.githubusercontent.com/29308176/206438093-3728e8de-18e9-4881-beb8-4f891bc19cdc.svg)
