### PR TITLE
FIX: default to non-resonant dynamics lineshape

### DIFF
--- a/src/ampform_dpd/__init__.py
+++ b/src/ampform_dpd/__init__.py
@@ -303,7 +303,7 @@ class DynamicsConfigurator:
 
     def get_builder(self, identifier) -> DynamicsBuilder:
         chain = self.__get_chain(identifier)
-        return self.__dynamics_builders[chain]
+        return self.__dynamics_builders.get(chain, formulate_non_resonant)
 
     def __get_chain(self, identifier) -> ThreeBodyDecayChain:
         if isinstance(identifier, ThreeBodyDecayChain):
@@ -329,6 +329,12 @@ class DynamicsBuilder(Protocol):
         self, decay_chain: ThreeBodyDecayChain
     ) -> tuple[sp.Expr, dict[sp.Symbol, float]]:
         ...
+
+
+def formulate_non_resonant(
+    decay_chain: ThreeBodyDecayChain,
+) -> tuple[sp.Expr, dict[sp.Symbol, float]]:
+    return sp.Rational(1), {}
 
 
 def simplify_latex_rendering() -> None:


### PR DESCRIPTION
Previously, the amplitude builder would crash if no dynamics were configured for certain resonances. After this PR, the builder falls back to 'non-resonant', that is, simply inserting $1$ as a dynamics parametrisation.

The need for this behaviour arose in a [comparison between non-DPD and DPD amplitudes](https://github.com/Leongrim/PWA-JPsi2pbarSigmaKS/issues/51), where the dynamics should be left out of the comparison.