### PR TITLE
DX: colorize `sphinx-build` output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ description =
   Build documentation with Sphinx
 passenv = *
 setenv =
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:doclive]
@@ -65,6 +66,7 @@ description =
   Set up a server to directly preview changes to the HTML pages
 passenv = *
 setenv =
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:docnb]
@@ -77,6 +79,7 @@ description =
 passenv = *
 setenv =
   EXECUTE_NB = yes
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:docnb-force]
@@ -87,6 +90,7 @@ commands =
 description =
   Execute Jupyter notebooks and build documentation with Sphinx
 setenv =
+  FORCE_COLOR = yes
   FORCE_EXECUTE_NB = yes
   PYTHONHASHSEED = 0
 
@@ -112,6 +116,8 @@ commands =
 description =
   Check external links in the documentation (requires internet connection)
 passenv = *
+setenv =
+  FORCE_COLOR = yes
 
 [testenv:nb]
 allowlist_externals =


### PR DESCRIPTION
- Closes https://github.com/ComPWA/repo-maintenance/issues/108
- Sets `passenv = *` to make the config DRY