### PR TITLE
FIX: use `pypa/gh-action-pypi-publish` directly

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -145,6 +145,7 @@
     "lineshapes",
     "matplotlib",
     "NumPy",
+    "PyPA",
     "pyplot",
     "pyright",
     "pytest",

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,10 +10,22 @@ jobs:
   milestone:
     if: startsWith(github.ref, 'refs/tags')
     uses: ComPWA/actions/.github/workflows/close-milestone.yml@v1
+  package-name:
+    uses: ComPWA/actions/.github/workflows/get-pypi-name.yml@v1
   pypi:
+    environment:
+      name: PyPI
+      url: https://pypi.org/p/${{ needs.package-name.outputs.name }}
     if: startsWith(github.ref, 'refs/tags')
-    secrets: inherit
-    uses: ComPWA/actions/.github/workflows/publish-to-pypi.yml@v1
+    name: Publish to PyPI
+    needs:
+      - package-name
+    permissions:
+      id-token: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: ComPWA/actions/build-pypi-distribution@v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
   push:
     if: startsWith(github.ref, 'refs/tags') && !github.event.release.prerelease
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
             metadata.vscode
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.2
+    rev: 0.3.3
     hooks:
       - id: check-dev-files
         args:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,8 @@
     "rewrap.wrappingColumn": 72
   },
   "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.wordWrap": "on"
   },
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
This PR should fix the deployment workflow for PyPI:
https://github.com/ComPWA/ampform-dpd/actions/runs/8350223738

See also https://github.com/ComPWA/actions/pull/71 and https://github.com/ComPWA/policy/pull/337