### PR TITLE
FIX: remove `IsobarNode` argument checks

### DIFF
--- a/src/ampform_dpd/decay.py
+++ b/src/ampform_dpd/decay.py
@@ -116,20 +116,6 @@ OuterStates = Dict[Literal[0, 1, 2, 3], Particle]
 class ThreeBodyDecayChain:
     decay: IsobarNode = field(validator=instance_of(IsobarNode))
 
-    def __attrs_post_init__(self) -> None:
-        if not isinstance(self.decay.child1, IsobarNode):
-            msg = f"Child 1 has of type {IsobarNode.__name__} (the decay)"
-            raise TypeError(msg)
-        if not isinstance(self.decay.child1.child1, Particle):
-            msg = f"Child 1 of child 1 has of type {Particle.__name__}"
-            raise TypeError(msg)
-        if not isinstance(self.decay.child1.child2, Particle):
-            msg = f"Child 2 of child 1 has of type {Particle.__name__}"
-            raise TypeError(msg)
-        if not isinstance(self.decay.child2, Particle):
-            msg = f"Child 2 has of type {Particle.__name__} (spectator)"
-            raise TypeError(msg)
-
     @property
     def parent(self) -> Particle:
         return self.decay.parent


### PR DESCRIPTION
Follow-up to #107. That PR makes it possible to set either `child1` or `child2` of the production `IsobarNode` be the resonance (decay) node, so the instance checks in the `IsobarNode` constructor have become outdated.