### PR TITLE
ENH: lower momentum subscripts in LaTeX rendering

### DIFF
--- a/src/ampform_dpd/dynamics/__init__.py
+++ b/src/ampform_dpd/dynamics/__init__.py
@@ -45,7 +45,7 @@ class P(sp.Expr):
     s: Any
     mi: Any
     mj: Any
-    _latex_repr_ = R"p_{{{mi},{mj}}}\left({s}\right)"
+    _latex_repr_ = R"p_{{_{{{mi},{mj}}}}}\left({s}\right)"
 
     def evaluate(self):
         s, mi, mj = self.args
@@ -57,7 +57,7 @@ class Q(sp.Expr):
     s: Any
     m0: Any
     mk: Any
-    _latex_repr_ = R"q_{{{m0},{mk}}}\left({s}\right)"
+    _latex_repr_ = R"q_{{_{{{m0},{mk}}}}}\left({s}\right)"
 
     def evaluate(self):
         s, m0, mk = self.args


### PR DESCRIPTION
Improvement for #123 and https://github.com/ComPWA/polarimetry/pull/358. It's subtle, but maybe it helps 😅 

### Old
```math
\begin{array}{rcl}
  \mathcal{R}^\mathrm{Flatté}\left(s\right) &=& \frac{1}{m^{2} - i m \left(\frac{\Gamma_{1} m p_{m_{1},m_{2}}\left(s\right)}{\sqrt{s} p_{m_{\pi},m_{\Sigma}}\left(m^{2}\right)} + \frac{\Gamma_{2} m p_{m_{\pi},m_{\Sigma}}\left(s\right)}{\sqrt{s} p_{m_{\pi},m_{\Sigma}}\left(m^{2}\right)}\right) - s} \\
\end{array}
```
### New
```math
\begin{array}{rcl}
  \mathcal{R}^\mathrm{Flatté}\left(s\right) &=& \frac{1}{m^{2} - i m \left(\frac{\Gamma_{1} m p_{_{m_{1},m_{2}}}\left(s\right)}{\sqrt{s} p_{_{m_{\pi},m_{\Sigma}}}\left(m^{2}\right)} + \frac{\Gamma_{2} m p_{_{m_{\pi},m_{\Sigma}}}\left(s\right)}{\sqrt{s} p_{_{m_{\pi},m_{\Sigma}}}\left(m^{2}\right)}\right) - s} \\
\end{array}
```