### PR TITLE
FIX: allow `Particle`+`State` in `as_markdown_table()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,9 @@ addopts = [
     "--ignore=docs/conf.py",
     "-m not slow",
 ]
+doctest_optionflags = [
+    "IGNORE_EXCEPTION_DETAIL",
+]
 filterwarnings = [
     "error",
     "ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning",

--- a/src/ampform_dpd/io.py
+++ b/src/ampform_dpd/io.py
@@ -111,13 +111,34 @@ def as_markdown_table(obj: Sequence) -> str:
 
 
 def _determine_item_type(obj) -> type:
+    """Determine the type of the items in a sequence.
+
+    >>> _determine_item_type([1, 2, 3])
+    <class 'int'>
+    >>> _determine_item_type([True, False])
+    <class 'bool'>
+    >>> _determine_item_type([True, False, 1])
+    <class 'int'>
+    >>> _determine_item_type([3.14, 1 + 1j])
+    Traceback (most recent call last):
+        ...
+    ValueError: Not all items are of type float'
+    """
     if not isinstance(obj, abc.Sequence):
         return type(obj)
     if len(obj) < 1:
         msg = "Need at least one entry to render a table"
         raise ValueError(msg)
-    item_type = type(obj[0])
-    if not all(isinstance(i, item_type) for i in obj):
+    existing_types = {type(i) for i in obj}
+    existing_types = {
+        typ
+        for typ in existing_types
+        if not any(
+            typ is not other and issubclass(typ, other) for other in existing_types
+        )
+    }
+    item_type = next(iter(existing_types))
+    if len(existing_types) != 1:
         msg = f"Not all items are of type {item_type.__name__}"
         raise ValueError(msg)
     return item_type


### PR DESCRIPTION
[`as_markdown_table()`](https://ampform-dpd.rtfd.io/0.2.0/api/ampform_dpd.io/#ampform_dpd.io.as_markdown_table) crashes if it gets a list with a combination of `Particle` and `State` objects. Encountered this while working on https://github.com/ComPWA/polarimetry/issues/357.