### PR TITLE
FIX: upgrade to AmpForm v0.15.3

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -3,7 +3,7 @@
 absl-py==2.1.0
 accessible-pygments==0.0.5
 alabaster==0.7.16
-ampform==0.15.2
+ampform==0.15.3
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -3,7 +3,7 @@
 absl-py==2.1.0
 accessible-pygments==0.0.5
 alabaster==0.7.16
-ampform==0.15.2
+ampform==0.15.3
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -3,7 +3,7 @@
 absl-py==2.1.0
 accessible-pygments==0.0.5
 alabaster==0.7.16
-ampform==0.15.2
+ampform==0.15.3
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -3,7 +3,7 @@
 absl-py==2.1.0
 accessible-pygments==0.0.4
 alabaster==0.7.13
-ampform==0.15.2
+ampform==0.15.3
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -3,7 +3,7 @@
 absl-py==2.1.0
 accessible-pygments==0.0.5
 alabaster==0.7.16
-ampform==0.15.2
+ampform==0.15.3
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0


### PR DESCRIPTION
This PR updates the [`pip` constraint files](https://github.com/ComPWA/update-pip-constraints?tab=readme-ov-file#update-pip-constraint-files) under the `.constraints/` directory and pre-commit hooks in [`.pre-commit-config.yaml`](https://pre-commit.com). It was created automatically by a scheduled workflow.