### PR TITLE
ENH: export `cached` aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ api_target_substitutions: dict[str, str | tuple[str, str]] = {
     "InitialStateID": ("obj", "ampform_dpd.decay.InitialStateID"),
     "Literal[-1, 1]": "typing.Literal",
     "Literal[(-1, 1)]": "typing.Literal",
+    "Model": "ampform.sympy.cached.Model",
     "Node": ("obj", "ampform_dpd.io.serialization.format.Node"),
     "NodeType": "typing.TypeVar",
     "ParameterValue": ("obj", "tensorwaves.interface.ParameterValue"),
@@ -62,6 +63,7 @@ api_target_substitutions: dict[str, str | tuple[str, str]] = {
     "qrules.topology.EdgeType": "typing.TypeVar",
     "qrules.topology.NodeType": "typing.TypeVar",
     "sp.acos": "sympy.functions.elementary.trigonometric.acos",
+    "sp.Basic": "sympy.core.basic.Basic",
     "sp.Expr": "sympy.core.expr.Expr",
     "sp.Indexed": "sympy.tensor.indexed.Indexed",
     "sp.Rational": "sympy.core.numbers.Rational",
@@ -215,6 +217,9 @@ nb_execution_show_tb = True
 nb_execution_timeout = -1
 nb_output_stderr = "show"
 nb_render_markdown_format = "myst"
+nitpick_ignore = [
+    ("py:class", "ampform.sympy.cached.Model"),
+]
 nitpicky = True
 primary_domain = "py"
 project = REPO_TITLE

--- a/src/ampform_dpd/io/cached.py
+++ b/src/ampform_dpd/io/cached.py
@@ -7,11 +7,7 @@ from typing import TYPE_CHECKING, overload
 
 import cloudpickle
 from ampform.sympy._cache import cache_to_disk  # noqa: PLC2701
-from ampform.sympy.cached import (
-    doit,  # noqa: F401  # pyright: ignore[reportUnusedImport]
-    unfold,  # noqa: F401  # pyright: ignore[reportUnusedImport]
-    xreplace,  # noqa: F401  # pyright: ignore[reportUnusedImport]
-)
+from ampform.sympy.cached import doit, unfold, xreplace
 from frozendict import frozendict
 from tensorwaves.function.sympy import create_function, create_parametrized_function
 
@@ -24,6 +20,13 @@ if TYPE_CHECKING:
         PositionalArgumentFunction,
     )
     from tensorwaves.interface import Function, ParameterValue, ParametrizedFunction
+
+__all__ = [
+    "doit",
+    "lambdify",
+    "unfold",
+    "xreplace",
+]
 
 
 @overload

--- a/src/ampform_dpd/io/cached.py
+++ b/src/ampform_dpd/io/cached.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, overload
 
 import cloudpickle
 from ampform.sympy._cache import cache_to_disk  # noqa: PLC2701
-from ampform.sympy.cached import doit, unfold, xreplace
+from ampform.sympy.cached import doit, simplify, subs, trigsimp, unfold, xreplace
 from frozendict import frozendict
 from tensorwaves.function.sympy import create_function, create_parametrized_function
 
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 __all__ = [
     "doit",
     "lambdify",
+    "simplify",
+    "subs",
+    "trigsimp",
     "unfold",
     "xreplace",
 ]


### PR DESCRIPTION
The `ampform_dpd.io.cached` aliases to `ampform.sympy.cached` are now exported through `__all__` to avoid [`reportPrivateImportUsage`](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage) linting errors.