### PR TITLE
ENH: support more types in `normalize_state_ids()`

### DIFF
--- a/src/ampform_dpd/adapter/qrules.py
+++ b/src/ampform_dpd/adapter/qrules.py
@@ -280,7 +280,13 @@ def _(obj: abc.Iterable[T]) -> list[T]:
 
 
 T = TypeVar(
-    "T", FrozenTransition, MutableTransition, ProblemSet, ReactionInfo, Transition
+    "T",
+    FrozenTransition,
+    MutableTransition,
+    ProblemSet,
+    ReactionInfo,
+    Topology,
+    Transition,
 )
 """Type variable for the input and output of :func:`normalize_state_ids`."""
 

--- a/src/ampform_dpd/adapter/qrules.py
+++ b/src/ampform_dpd/adapter/qrules.py
@@ -10,8 +10,14 @@ from typing import TYPE_CHECKING, Any, NoReturn, TypeVar, overload
 import attrs
 import qrules
 from qrules.quantum_numbers import InteractionProperties
-from qrules.topology import EdgeType, FrozenTransition, NodeType
-from qrules.transition import ReactionInfo, StateTransition, Topology
+from qrules.topology import (
+    EdgeType,
+    FrozenTransition,
+    MutableTransition,
+    NodeType,
+    Transition,
+)
+from qrules.transition import ReactionInfo, Topology
 
 from ampform_dpd.decay import (
     FinalStateID,
@@ -240,8 +246,12 @@ def _(obj: ReactionInfo) -> ReactionInfo:
     )
 
 
-@_impl_normalize_state_ids.register(FrozenTransition)  # type:ignore[attr-defined]
-def _(obj: StateTransition) -> StateTransition:
+_Transition = TypeVar("_Transition", FrozenTransition, MutableTransition)
+
+
+@_impl_normalize_state_ids.register(FrozenTransition)
+@_impl_normalize_state_ids.register(MutableTransition)
+def _(obj: _Transition) -> _Transition:
     return attrs.evolve(
         obj,
         topology=_impl_normalize_state_ids(obj.topology),
@@ -260,7 +270,7 @@ def _(obj: abc.Iterable[T]) -> list[T]:
     return [_impl_normalize_state_ids(x) for x in obj]
 
 
-T = TypeVar("T", ReactionInfo, StateTransition, Topology)
+T = TypeVar("T", ReactionInfo, FrozenTransition, MutableTransition, Transition)
 """Type variable for the input and output of :func:`normalize_state_ids`."""
 
 

--- a/src/ampform_dpd/adapter/qrules.py
+++ b/src/ampform_dpd/adapter/qrules.py
@@ -17,7 +17,7 @@ from qrules.topology import (
     NodeType,
     Transition,
 )
-from qrules.transition import ReactionInfo, Topology
+from qrules.transition import ProblemSet, ReactionInfo, Topology
 
 from ampform_dpd.decay import (
     FinalStateID,
@@ -259,6 +259,15 @@ def _(obj: _Transition) -> _Transition:
     )
 
 
+@_impl_normalize_state_ids.register(ProblemSet)
+def _(obj: ProblemSet) -> ProblemSet:
+    return ProblemSet(
+        initial_facts=_impl_normalize_state_ids(obj.initial_facts),
+        solving_settings=_impl_normalize_state_ids(obj.solving_settings),
+        topology=_impl_normalize_state_ids(obj.topology),
+    )
+
+
 @_impl_normalize_state_ids.register(Topology)  # type:ignore[attr-defined]
 def _(obj: Topology) -> Topology:
     mapping = {old: new for new, old in enumerate(sorted(obj.edges))}
@@ -270,7 +279,9 @@ def _(obj: abc.Iterable[T]) -> list[T]:
     return [_impl_normalize_state_ids(x) for x in obj]
 
 
-T = TypeVar("T", ReactionInfo, FrozenTransition, MutableTransition, Transition)
+T = TypeVar(
+    "T", FrozenTransition, MutableTransition, ProblemSet, ReactionInfo, Transition
+)
 """Type variable for the input and output of :func:`normalize_state_ids`."""
 
 

--- a/tests/adapter/test_qrules.py
+++ b/tests/adapter/test_qrules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, SupportsFloat
 
 import pytest
+from qrules import InteractionType, StateTransitionManager
 
 from ampform_dpd.adapter.qrules import (
     _convert_transition,
@@ -115,6 +116,21 @@ def test_normalize_state_ids_reaction(jpsi2pksigma_reaction: ReactionInfo):
 
         for i in transition012.states:
             assert transition012.states[i] == transition123.states[i + 1]
+
+
+def test_normalize_state_ids_problem_set():
+    stm = StateTransitionManager(
+        initial_state=[("J/psi(1S)", [-1, +1])],
+        final_state=["K0", "Sigma+", "p~"],
+        allowed_intermediate_particles=["N(1700)", "Sigma(1750)"],
+        formalism="helicity",
+        mass_conservation_factor=0,
+    )
+    stm.set_allowed_interaction_types([InteractionType.STRONG, InteractionType.EM])
+    problem_sets = stm.create_problem_sets()
+    some_problem_set = normalize_state_ids(problem_sets[3600.0][0])
+    assert set(some_problem_set.initial_facts.initial_states) == {0}
+    assert set(some_problem_set.initial_facts.final_states) == {1, 2, 3}
 
 
 def test_permute_equal_final_states(


### PR DESCRIPTION
The [`normalize_state_ids()`](https://ampform-dpd.readthedocs.io/0.2.3/api/ampform_dpd.adapter.qrules.html#ampform_dpd.adapter.qrules.normalize_state_ids) function now supports [`MutableTransition`](https://qrules.readthedocs.io/0.10.5/api/qrules.topology.html#qrules.topology.MutableTransition) and [`ProblemSet`](https://qrules.readthedocs.io/0.10.5/api/qrules.transition.html#qrules.transition.ProblemSet). This can be useful in visualising intermediate solutions.

> [!NOTE]
> It starts to look like this function should be moved to QRules itself.
