### PR TITLE
BREAK: use `DefinedExpression` in dynamics builder

### DIFF
--- a/docs/lc2pkpi.ipynb
+++ b/docs/lc2pkpi.ipynb
@@ -31,7 +31,7 @@
     "import sympy as sp\n",
     "from IPython.display import Latex, Markdown\n",
     "\n",
-    "from ampform_dpd import DalitzPlotDecompositionBuilder\n",
+    "from ampform_dpd import DalitzPlotDecompositionBuilder, DefinedExpression\n",
     "from ampform_dpd.adapter.qrules import (\n",
     "    load_particles,\n",
     "    normalize_state_ids,\n",
@@ -194,7 +194,7 @@
    "source": [
     "def formulate_breit_wigner(\n",
     "    decay_chain: ThreeBodyDecayChain,\n",
-    ") -> tuple[BreitWignerMinL, dict[sp.Symbol, float]]:\n",
+    ") -> DefinedExpression:\n",
     "    s = get_mandelstam_s(decay_chain.decay_node)\n",
     "    child1_mass, child2_mass = map(create_mass_symbol, decay_chain.decay_products)\n",
     "    l_dec = sp.Rational(decay_chain.outgoing_ls.L)\n",
@@ -231,7 +231,7 @@
     "        R_dec,\n",
     "        R_prod,\n",
     "    )\n",
-    "    return dynamics, parameter_defaults"
+    "    return DefinedExpression(dynamics, parameter_defaults)"
    ]
   },
   {
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that subsystem `3` (with the $\\Lambda^*$ resonances and recoil $\\pi^+$) has been selected as reference subsystem for the Wigner‑$d$ functions. This is computationally more efficient, because that subsystem contains most resonances."
+    "Notice that subsystem `3` (with the $\\varLambda^*$ resonances and recoil $\\pi^+$) has been selected as reference subsystem for the Wigner‑$d$ functions. This is computationally more efficient, because that subsystem contains most resonances."
    ]
   },
   {
@@ -331,7 +331,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/docs/serialization.ipynb
+++ b/docs/serialization.ipynb
@@ -433,7 +433,7 @@
     "    final_state = get_final_state(model)\n",
     "    return DefinedExpression(\n",
     "        expression=BuggBreitWigner(s, mass, width, m1, m2, γ),\n",
-    "        definitions={\n",
+    "        parameters={\n",
     "            mass: function_definition[\"mass\"],\n",
     "            width: function_definition[\"width\"],\n",
     "            m1: final_state[i].mass,\n",
@@ -989,7 +989,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/src/ampform_dpd/io/__init__.py
+++ b/src/ampform_dpd/io/__init__.py
@@ -87,7 +87,7 @@ def _(obj: DefinedExpression, **kwargs) -> str:
         latex += Rf"  {aslatex(obj.expression, **kwargs)} \\" + "\n"
     else:
         latex += Rf"  {aslatex(expr)} &=& {aslatex(unfolded)} \\" + "\n"
-    for lhs, rhs in obj.definitions.items():
+    for lhs, rhs in obj.parameters.items():
         latex += Rf"  {aslatex(lhs)} &=& {aslatex(rhs)} \\" + "\n"
     latex += R"\end{array}"
     return latex

--- a/src/ampform_dpd/io/serialization/amplitude.py
+++ b/src/ampform_dpd/io/serialization/amplitude.py
@@ -154,7 +154,7 @@ def formulate_chain_amplitude(  # noqa: PLR0914, PLR0917
     return {
         amplitude_symbol: amplitude_expression,
         weight: weight_val,
-        **dynamics.definitions,
+        **dynamics.parameters,
         θij: θij_expr,
     }
 

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -89,7 +89,7 @@ def formulate_form_factor(vertex: Vertex, model: ModelDefinition) -> DefinedExpr
         angular_momentum = int(function_definition["l"])
         return DefinedExpression(
             expression=FormFactor(s, m1, m2, angular_momentum, meson_radius),
-            definitions={
+            parameters={
                 meson_radius: function_definition["radius"],
             },
         )
@@ -113,7 +113,7 @@ def formulate_breit_wigner(
     d = sp.Symbol(R"R_\mathrm{res}", nonnegative=True)
     return DefinedExpression(
         expression=BreitWigner(s, mass, width, m1, m2, angular_momentum, d),
-        definitions={
+        parameters={
             mass: function_definition["mass"],
             width: function_definition["width"],
             m1: function_definition["ma"],
@@ -164,7 +164,7 @@ def formulate_multichannel_breit_wigner(  # noqa: PLR0914
         })
     return DefinedExpression(
         expression=MultichannelBreitWigner(s, mass, tuple(channels)),
-        definitions=parameter_defaults,
+        parameters=parameter_defaults,
     )
 
 


### PR DESCRIPTION
- Closes #135
- Dynamics builders now need to return a `DefinedExpression` object
- `DefinedExpression.definitions` has been renamed to `parameters`
- `create_mass_symbol()` has been moved from `ampform_dpd.dynamics.builder` to `ampform_dpd`