### PR TITLE
FEAT: support generic serialized functions

### DIFF
--- a/docs/Lc2ppiK.json
+++ b/docs/Lc2ppiK.json
@@ -1,7 +1,7 @@
 {
   "distributions": [
     {
-      "name": "my_model_for_reaction_intensity",
+      "name": "default_model",
       "type": "HadronicUnpolarizedIntensity",
       "decay_description": {
         "kinematics": {
@@ -96,7 +96,7 @@
                 "parametrization": "L1520_BW"
               }
             ],
-            "weight": "0.146999 + 0.022162i",
+            "weight": "3.605175244894445 + 0.5435267843818713i",
             "vertices": [
               {
                 "type": "helicity",
@@ -123,7 +123,7 @@
                 "parametrization": "L1520_BW"
               }
             ],
-            "weight": "-0.0803435 + 0.7494165i",
+            "weight": "-1.9704378756874323 + 18.379565942050206i",
             "vertices": [
               {
                 "type": "helicity",
@@ -150,7 +150,7 @@
                 "parametrization": "L1600_BW"
               }
             ],
-            "weight": "4.929406127531439 - 0.5956915012088891i",
+            "weight": "10.062771632071723 - 1.2160303664881582i",
             "vertices": [
               {
                 "type": "helicity",
@@ -177,7 +177,7 @@
                 "parametrization": "L1600_BW"
               }
             ],
-            "weight": "-3.4228557332438796 - 2.179858885546952i",
+            "weight": "-6.987335732146143 - 4.449911731331869i",
             "vertices": [
               {
                 "type": "helicity",
@@ -258,7 +258,7 @@
                 "parametrization": "L1690_BW"
               }
             ],
-            "weight": "-0.192886 - 0.0551175i",
+            "weight": "-1.5899154261176556 - 0.4543210160355851i",
             "vertices": [
               {
                 "type": "helicity",
@@ -285,7 +285,7 @@
                 "parametrization": "L1690_BW"
               }
             ],
-            "weight": "-1.365296 - 0.1768065i",
+            "weight": "-11.25382439169629 - 1.4573757648967332i",
             "vertices": [
               {
                 "type": "helicity",
@@ -366,7 +366,7 @@
                 "parametrization": "D1232_BW"
               }
             ],
-            "weight": "-3.3890955 + 1.5259025i",
+            "weight": "-10.91657692017265 + 4.915067165836356i",
             "vertices": [
               {
                 "type": "helicity",
@@ -393,7 +393,7 @@
                 "parametrization": "D1232_BW"
               }
             ],
-            "weight": "-6.4935965 + 2.264168i",
+            "weight": "-20.916449737345527 + 7.29308576054982i",
             "vertices": [
               {
                 "type": "helicity",
@@ -420,7 +420,7 @@
                 "parametrization": "D1600_BW"
               }
             ],
-            "weight": "5.7007925 - 1.5627555i",
+            "weight": "10.394484212696474 - 2.8494349466419946i",
             "vertices": [
               {
                 "type": "helicity",
@@ -447,7 +447,7 @@
                 "parametrization": "D1600_BW"
               }
             ],
-            "weight": "3.3646055 - 0.5011915i",
+            "weight": "6.134820509903093 - 0.9138426164937006i",
             "vertices": [
               {
                 "type": "helicity",
@@ -474,7 +474,7 @@
                 "parametrization": "D1700_BW"
               }
             ],
-            "weight": "-5.18914 - 0.717436i",
+            "weight": "-29.25264941105087 - 4.044389587266232i",
             "vertices": [
               {
                 "type": "helicity",
@@ -501,7 +501,7 @@
                 "parametrization": "D1700_BW"
               }
             ],
-            "weight": "-6.437051 - 1.052785i",
+            "weight": "-36.28747656529877 - 5.93484672030687i",
             "vertices": [
               {
                 "type": "helicity",
@@ -582,7 +582,7 @@
                 "parametrization": "K892_BW"
               }
             ],
-            "weight": "0.6885560139393164 - 0.5922539890384868i",
+            "weight": "1.7222349176997693 - 1.481361689419436i",
             "vertices": [
               {
                 "type": "helicity",
@@ -609,7 +609,7 @@
                 "parametrization": "K892_BW"
               }
             ],
-            "weight": "-0.4198173614898905 - 2.398905956940163i",
+            "weight": "-1.0500585346397064 - 6.000208435743097i",
             "vertices": [
               {
                 "type": "helicity",
@@ -636,7 +636,7 @@
                 "parametrization": "K892_BW"
               }
             ],
-            "weight": "0.5773502691896258 + 0.0i",
+            "weight": "1.4440841024000803 + 0.0i",
             "vertices": [
               {
                 "type": "helicity",
@@ -663,7 +663,7 @@
                 "parametrization": "K892_BW"
               }
             ],
-            "weight": "-1.8137146937446735 - 1.9014511500518056i",
+            "weight": "-4.536512227148323 - 4.755961023685448i",
             "vertices": [
               {
                 "type": "helicity",
@@ -756,6 +756,7 @@
     {
       "name": "L1405_Flatte",
       "type": "MultichannelBreitWigner",
+      "x": "m_31_sq",
       "mass": 1.4051,
       "channels": [
         {
@@ -779,6 +780,7 @@
       "l": 2,
       "mb": 0.938272046,
       "type": "BreitWigner",
+      "x": "m_31_sq",
       "d": 1.5,
       "mass": 1.69,
       "ma": 0.493677,
@@ -789,6 +791,7 @@
       "l": 1,
       "mb": 0.13957018,
       "type": "BreitWigner",
+      "x": "m_12_sq",
       "d": 1.5,
       "mass": 1.232,
       "ma": 0.938272046,
@@ -799,6 +802,7 @@
       "l": 2,
       "mb": 0.938272046,
       "type": "BreitWigner",
+      "x": "m_31_sq",
       "d": 1.5,
       "mass": 1.518467,
       "ma": 0.493677,
@@ -809,6 +813,7 @@
       "l": 1,
       "mb": 0.938272046,
       "type": "BreitWigner",
+      "x": "m_31_sq",
       "d": 1.5,
       "mass": 1.63,
       "ma": 0.493677,
@@ -819,6 +824,7 @@
       "l": 0,
       "mb": 0.938272046,
       "type": "BreitWigner",
+      "x": "m_31_sq",
       "d": 1.5,
       "mass": 1.98819,
       "ma": 0.493677,
@@ -829,6 +835,7 @@
       "l": 1,
       "mb": 0.13957018,
       "type": "BreitWigner",
+      "x": "m_12_sq",
       "d": 1.5,
       "mass": 1.64,
       "ma": 0.938272046,
@@ -839,6 +846,7 @@
       "l": 2,
       "mb": 0.13957018,
       "type": "BreitWigner",
+      "x": "m_12_sq",
       "d": 1.5,
       "mass": 1.69,
       "ma": 0.938272046,
@@ -849,6 +857,7 @@
       "l": 1,
       "mb": 0.493677,
       "type": "BreitWigner",
+      "x": "m_23_sq",
       "d": 1.5,
       "mass": 0.8955,
       "ma": 0.13957018,
@@ -856,23 +865,20 @@
     },
     {
       "name": "K700_BuggBW",
-      "slope": 0.94106,
-      "type": "BreitWignerWidthExpLikeBugg",
-      "mass": 0.824,
-      "width": 0.478
+      "type": "generic_function",
+      "expression": "1/(0.824^2 - σ - i * 0.824 * (σ - 0.23397706275638377) / (0.824^2 - 0.23397706275638377) * 0.478 * exp(-0.941060 * σ))"
     },
     {
       "name": "K1430_BuggBW",
-      "slope": 0.020981,
-      "type": "BreitWignerWidthExpLikeBugg",
-      "mass": 1.375,
-      "width": 0.19
+      "type": "generic_function",
+      "expression": "1/(1.375^2 - σ - i * 1.375 * (σ - 0.23397706275638377) / (1.375^2 - 0.23397706275638377) * 0.190 * exp(-0.020981 * σ))"
     },
     {
       "name": "L1670_BW",
       "l": 0,
       "mb": 0.938272046,
       "type": "BreitWigner",
+      "x": "m_31_sq",
       "d": 1.5,
       "mass": 1.67,
       "ma": 0.493677,
@@ -939,7 +945,7 @@
     "amplitude_model_checksums": [
       {
         "point": "validation_point",
-        "distribution": "my_model_for_reaction_intensity",
+        "distribution": "default_model",
         "value": 9345.853380852355
       },
       {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,6 +178,7 @@ html_theme_options = {
     "show_toc_level": 2,
     "use_download_button": False,
     "use_edit_page_button": True,
+    "use_fullscreen_button": False,
     "use_issues_button": True,
     "use_repository_button": True,
     "use_source_button": True,

--- a/docs/serialization.ipynb
+++ b/docs/serialization.ipynb
@@ -51,14 +51,8 @@
     "from IPython.display import JSON, Math\n",
     "from tqdm.auto import tqdm\n",
     "\n",
-    "from ampform_dpd import DefinedExpression\n",
     "from ampform_dpd.decay import FinalStateID, State, ThreeBodyDecay\n",
-    "from ampform_dpd.dynamics import (\n",
-    "    BreitWigner,\n",
-    "    BuggBreitWigner,\n",
-    "    ChannelArguments,\n",
-    "    MultichannelBreitWigner,\n",
-    ")\n",
+    "from ampform_dpd.dynamics import BreitWigner, ChannelArguments, MultichannelBreitWigner\n",
     "from ampform_dpd.io import (\n",
     "    aslatex,\n",
     "    cached,\n",
@@ -75,18 +69,14 @@
     "    formulate_chain_amplitude,\n",
     "    formulate_recoupling,\n",
     ")\n",
-    "from ampform_dpd.io.serialization.decay import get_final_state, to_decay\n",
+    "from ampform_dpd.io.serialization.decay import to_decay\n",
     "from ampform_dpd.io.serialization.dynamics import (\n",
     "    formulate_breit_wigner,\n",
     "    formulate_dynamics,\n",
     "    formulate_form_factor,\n",
     "    formulate_multichannel_breit_wigner,\n",
-    "    to_mandelstam_symbol,\n",
-    "    to_mass_symbol,\n",
     ")\n",
     "from ampform_dpd.io.serialization.format import (\n",
-    "    ModelDefinition,\n",
-    "    Propagator,\n",
     "    get_decay_chains,\n",
     "    get_function_definition,\n",
     ")\n",
@@ -363,29 +353,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The model contains one lineshape function that is not standard, so we have to implement a custom propagator dynamics builder for this.\n",
-    "\n",
-    ":::{note}\n",
-    "The model file in this repository predates [RUB-EP1/amplitude-serialization#69](https://github.com/RUB-EP1/amplitude-serialization/pull/69), which replaced this lineshape with a `generic_function` expression string. See [ComPWA/ampform-dpd#205](https://github.com/ComPWA/ampform-dpd/issues/205).\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": [
-     "hide-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "s, m0, Γ0, m1, m2, γ = sp.symbols(\"s m0 Gamma0 m1 m2 gamma\", nonnegative=True)\n",
-    "expr = BuggBreitWigner(s, m0, Γ0, m1, m2, γ)\n",
-    "Math(aslatex({expr: expr.doit(deep=False)}))"
+    "The Bugg lineshapes are serialized as `generic_function` expression strings. The built-in dynamics builder parses these expressions and substitutes $i$ and $\\sigma$ with the imaginary unit and the Mandelstam variable of the propagator node, respectively."
    ]
   },
   {
@@ -407,77 +375,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "mystnb": {
-     "code_prompt_show": "Dynamics builder for the Bugg Breit–Wigner"
-    },
-    "tags": [
-     "hide-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def formulate_bugg_breit_wigner(\n",
-    "    propagator: Propagator, resonance: str, model: ModelDefinition\n",
-    ") -> DefinedExpression:\n",
-    "    function_definition = get_function_definition(propagator[\"parametrization\"], model)\n",
-    "    node = propagator[\"node\"]\n",
-    "    i, j = node\n",
-    "    s = to_mandelstam_symbol(node)\n",
-    "    mass = sp.Symbol(f\"m_{{{resonance}}}\", nonnegative=True)\n",
-    "    width = sp.Symbol(Rf\"\\Gamma_{{{resonance}}}\", nonnegative=True)\n",
-    "    γ = sp.Symbol(Rf\"\\gamma_{{{resonance}}}\", nonnegative=True)\n",
-    "    m1 = to_mass_symbol(i)\n",
-    "    m2 = to_mass_symbol(j)\n",
-    "    final_state = get_final_state(model)\n",
-    "    return DefinedExpression(\n",
-    "        expression=BuggBreitWigner(s, mass, width, m1, m2, γ),\n",
-    "        parameters={\n",
-    "            mass: function_definition[\"mass\"],\n",
-    "            width: function_definition[\"width\"],\n",
-    "            m1: final_state[i].mass,\n",
-    "            m2: final_state[j].mass,\n",
-    "            γ: function_definition[\"slope\"],\n",
-    "        },\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CHAIN_18 = CHAIN_DEFS[18]\n",
-    "K700_BuggBW = formulate_bugg_breit_wigner(\n",
-    "    propagator=CHAIN_18[\"propagators\"][0],\n",
-    "    resonance=to_latex(CHAIN_18[\"name\"]),\n",
-    "    model=MODEL_DEFINITION,\n",
-    ")\n",
-    "Math(aslatex(K700_BuggBW))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### General propagator dynamics builder"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DYNAMICS_BUILDERS = {\n",
-    "    \"BreitWignerWidthExpLikeBugg\": formulate_bugg_breit_wigner,\n",
-    "}"
    ]
   },
   {
@@ -495,9 +396,9 @@
    "outputs": [],
    "source": [
     "exprs = [\n",
-    "    formulate_dynamics(CHAIN_DEFS[0], MODEL_DEFINITION, to_latex, DYNAMICS_BUILDERS),\n",
-    "    formulate_dynamics(CHAIN_DEFS[18], MODEL_DEFINITION, to_latex, DYNAMICS_BUILDERS),\n",
-    "    formulate_dynamics(CHAIN_DEFS[20], MODEL_DEFINITION, to_latex, DYNAMICS_BUILDERS),\n",
+    "    formulate_dynamics(CHAIN_DEFS[0], MODEL_DEFINITION, to_latex),\n",
+    "    formulate_dynamics(CHAIN_DEFS[18], MODEL_DEFINITION, to_latex),\n",
+    "    formulate_dynamics(CHAIN_DEFS[20], MODEL_DEFINITION, to_latex),\n",
     "]\n",
     "Math(aslatex(exprs))"
    ]
@@ -561,7 +462,7 @@
     "    chain = CHAINS_BY_PROPAGATOR.get(parametrization)\n",
     "    if chain is None:  # the checksum is for the full intensity, not a propagator\n",
     "        continue\n",
-    "    dynamics = formulate_dynamics(chain, MODEL_DEFINITION, to_latex, DYNAMICS_BUILDERS)\n",
+    "    dynamics = formulate_dynamics(chain, MODEL_DEFINITION, to_latex)\n",
     "    expr = dynamics.expression.doit().xreplace(dynamics.parameters)\n",
     "    (variable,) = expr.free_symbols\n",
     "    (value,) = PARAMETER_POINTS[checksum[\"point\"]].values()\n",
@@ -741,7 +642,6 @@
    "source": [
     "MODEL = formulate(\n",
     "    MODEL_DEFINITION,\n",
-    "    additional_builders=DYNAMICS_BUILDERS,\n",
     "    cleanup_summations=True,\n",
     "    to_latex=to_latex,\n",
     ")\n",

--- a/docs/serialization.ipynb
+++ b/docs/serialization.ipynb
@@ -488,8 +488,11 @@
     "jupyter": {
      "source_hidden": true
     },
+    "mystnb": {
+     "code_prompt_show": "Assert that the propagators match the reference values"
+    },
     "tags": [
-     "remove-input"
+     "hide-input"
     ]
    },
    "outputs": [],
@@ -722,8 +725,11 @@
     "jupyter": {
      "source_hidden": true
     },
+    "mystnb": {
+     "code_prompt_show": "Assert that only the Mandelstam variables remain"
+    },
     "tags": [
-     "remove-input"
+     "hide-input"
     ]
    },
    "outputs": [],
@@ -906,8 +912,11 @@
     "jupyter": {
      "source_hidden": true
     },
+    "mystnb": {
+     "code_prompt_show": "Assert that the intensities are not all NaN"
+    },
     "tags": [
-     "remove-input"
+     "hide-input"
     ]
    },
    "outputs": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,6 +363,7 @@ docstring-code-format = true
 line-ending = "lf"
 
 [tool.ruff.lint]
+allowed-confusables = ["σ"]
 ignore = [
     "ANN",
     "ARG00",

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -110,7 +110,7 @@ def formulate_generic_function(
     return DefinedExpression(
         expression=parse_expr(
             expression,
-            local_dict={"i": sp.I, "\N{GREEK SMALL LETTER SIGMA}": mandelstam},
+            local_dict={"i": sp.I, "σ": mandelstam},
         )
     )
 

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
 import sympy as sp
 from ampform.dynamics.form_factor import FormFactor
+from sympy.parsing.sympy_parser import parse_expr
 
 from ampform_dpd import DefinedExpression
 from ampform_dpd.dynamics import BreitWigner, ChannelArguments, MultichannelBreitWigner
@@ -13,6 +14,7 @@ from ampform_dpd.io.serialization.format import (
     BlattWeisskopfDefinition,
     BreitWignerDefinition,
     DecayChain,
+    GenericFunctionDefinition,
     ModelDefinition,
     MultichannelBreitWignerDefinition,
     Propagator,
@@ -49,6 +51,7 @@ def formulate_dynamics(
 ) -> DefinedExpression:
     definitions: dict[str, PropagatorDynamicsBuilder] = {
         "BreitWigner": formulate_breit_wigner,
+        "generic_function": formulate_generic_function,
         "MultichannelBreitWigner": formulate_multichannel_breit_wigner,
     }
     if additional_definitions is not None:
@@ -95,6 +98,21 @@ def formulate_form_factor(vertex: Vertex, model: ModelDefinition) -> DefinedExpr
         )
     msg = f"No form factor implementation for {function_name!r}"
     raise NotImplementedError(msg)
+
+
+def formulate_generic_function(
+    propagator: Propagator, resonance: str, model: ModelDefinition
+) -> DefinedExpression:
+    function_definition = get_function_definition(propagator["parametrization"], model)
+    function_definition = cast("GenericFunctionDefinition", function_definition)
+    expression = function_definition["expression"].replace("^", "**")
+    mandelstam = to_mandelstam_symbol(propagator["node"])
+    return DefinedExpression(
+        expression=parse_expr(
+            expression,
+            local_dict={"i": sp.I, "\N{GREEK SMALL LETTER SIGMA}": mandelstam},
+        )
+    )
 
 
 def formulate_breit_wigner(

--- a/src/ampform_dpd/io/serialization/format.py
+++ b/src/ampform_dpd/io/serialization/format.py
@@ -113,6 +113,10 @@ class BreitWignerDefinition(FunctionDefinition):
     d: float
 
 
+class GenericFunctionDefinition(FunctionDefinition):
+    expression: str
+
+
 class MultichannelBreitWignerDefinition(FunctionDefinition):
     mass: float
     channels: list[ChannelParameters]

--- a/tests/io_serialization/test_dynamics.py
+++ b/tests/io_serialization/test_dynamics.py
@@ -19,8 +19,7 @@ def test_formulate_generic_function():
             GenericFunctionDefinition(
                 name="custom",
                 type="generic_function",
-                expression="1 / (2^2 - \N{GREEK SMALL LETTER SIGMA} "
-                "- i * exp(-0.5 * \N{GREEK SMALL LETTER SIGMA}))",
+                expression="1 / (2^2 - σ - i * exp(-0.5 * σ))",
             )
         ],
         domains=[],

--- a/tests/io_serialization/test_dynamics.py
+++ b/tests/io_serialization/test_dynamics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+import sympy as sp
+
+from ampform_dpd.io.serialization.dynamics import formulate_dynamics
+from ampform_dpd.io.serialization.format import (
+    DecayChain,
+    GenericFunctionDefinition,
+    ModelDefinition,
+    get_decay_chains,
+)
+
+
+def test_formulate_generic_function():
+    model = ModelDefinition(
+        distributions=[],
+        functions=[
+            GenericFunctionDefinition(
+                name="custom",
+                type="generic_function",
+                expression="1 / (2^2 - \N{GREEK SMALL LETTER SIGMA} "
+                "- i * exp(-0.5 * \N{GREEK SMALL LETTER SIGMA}))",
+            )
+        ],
+        domains=[],
+        misc={},
+        parameter_points=[],
+    )
+    chain = DecayChain(
+        name="resonance",
+        propagators=[{"spin": "0", "node": (2, 3), "parametrization": "custom"}],
+        vertices=[],
+        topology=[1, [2, 3]],
+        kinematics={
+            "initial_state": {"index": 0, "name": "X", "spin": "0", "mass": 1.0},
+            "final_state": [],
+        },
+        weight="1",
+    )
+
+    dynamics = formulate_dynamics(chain, model)
+
+    σ1 = sp.Symbol("sigma1", nonnegative=True)
+    assert dynamics.expression == 1 / (4 - σ1 - sp.I * sp.exp(-sp.Float(0.5) * σ1))
+    assert dynamics.parameters == {}
+
+
+@pytest.mark.parametrize("chain_id", [18, 19, 24, 25])
+def test_formulate_bugg_lineshapes(model_definition: ModelDefinition, chain_id: int):
+    chain = get_decay_chains(model_definition)[chain_id]
+
+    dynamics = formulate_dynamics(chain, model_definition)
+
+    assert dynamics.expression.free_symbols == {sp.Symbol("sigma1", nonnegative=True)}


### PR DESCRIPTION
Closes #205 

## ✨ New features

- New `formulate_generic_function()` builder in `ampform_dpd.io.serialization.dynamics` for `generic_function` lineshape definitions. It parses the `expression` field into a SymPy expression, mapping `^` onto `**`, `i` onto the imaginary unit, and `σ` onto the Mandelstam symbol of the propagator node.
- `generic_function` is registered in the default builder table of `formulate_dynamics()`, so models that serialize non-standard lineshapes as expression strings now work out of the box, without passing `additional_definitions`.

## 📝 Documentation

- `docs/Lc2ppiK.json` is re-vendored from [RUB-EP1/amplitude-serialization@`e43ce61`](https://github.com/RUB-EP1/amplitude-serialization/blob/e43ce61e0b3d2b1df8389b70926fa076b5749a8b/models/lc2ppik-lhcb-2683025.json). The Bugg lineshapes are now `generic_function` definitions, the function definitions carry an `x` field, and the checksums come from upstream instead of being back-ported by hand.
- The fullscreen button is hidden in the Sphinx Book Theme options.

## Squash commit messages

```text
* DOC: hide fullscreen button in the documentation
* DOC: vendor upstream `Lc2ppiK.json` model definition
* DX: test `generic_function` dynamics builder
```