### PR TITLE
FIX: use cyclic pair ordering for LS couplings

### DIFF
--- a/src/ampform_dpd/__init__.py
+++ b/src/ampform_dpd/__init__.py
@@ -27,6 +27,7 @@ from sympy.physics.quantum.spin import Rotation as Wigner
 
 from ampform_dpd.angles import formulate_scattering_angle, formulate_zeta_angle
 from ampform_dpd.decay import (
+    DecayNode,
     FinalStateID,
     IsobarNode,
     LSCoupling,
@@ -229,7 +230,7 @@ class DalitzPlotDecompositionBuilder:
             )
             if not self.use_decay_helicity_couplings:
                 amplitude *= _formulate_clebsch_gordan_factors(
-                    chain.decay_node,
+                    _order_decay_products(chain.decay_node, i),
                     helicities={
                         self.decay.final_state[i]: λ[i],
                         self.decay.final_state[j]: λ[j],
@@ -391,6 +392,23 @@ def _get_coupling_base(
     if helicity_basis:
         return sp.IndexedBase(Rf"\mathcal{{H}}^\mathrm{{{typ}}}")
     return sp.IndexedBase(Rf"\mathcal{{H}}^\mathrm{{LS,{typ}}}")
+
+
+def _order_decay_products(isobar: DecayNode, first_id: FinalStateID) -> DecayNode:
+    """Write the children of a decay node in the DPD cyclic pair ordering.
+
+    The Clebsch-Gordan factors of an isobar node depend on which of its two children is
+    listed first, and so does the isobar Wigner-:math:`d` function. The latter is
+    constructed from `.get_decay_product_ids`, which follows the cyclic pair ordering
+    :math:`(23)1, (31)2, (12)3` of `the DPD paper
+    <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.101.034033>`_ (Eq. 7), so the
+    node has to be brought into that same ordering before its Clebsch-Gordan factors are
+    formulated.
+    """
+    child1 = to_particle(isobar.child1)
+    if isinstance(child1, State) and child1.index == first_id:
+        return isobar
+    return attrs.evolve(isobar, child1=isobar.child2, child2=isobar.child1)
 
 
 def _formulate_clebsch_gordan_factors(

--- a/src/ampform_dpd/__init__.py
+++ b/src/ampform_dpd/__init__.py
@@ -230,7 +230,7 @@ class DalitzPlotDecompositionBuilder:
             )
             if not self.use_decay_helicity_couplings:
                 amplitude *= _formulate_clebsch_gordan_factors(
-                    _order_decay_products(chain.decay_node, i),
+                    isobar=_order_decay_products(chain.decay_node, first_id=i),
                     helicities={
                         self.decay.final_state[i]: λ[i],
                         self.decay.final_state[j]: λ[j],
@@ -397,13 +397,13 @@ def _get_coupling_base(
 def _order_decay_products(isobar: DecayNode, first_id: FinalStateID) -> DecayNode:
     """Write the children of a decay node in the DPD cyclic pair ordering.
 
-    The Clebsch-Gordan factors of an isobar node depend on which of its two children is
+    The Clebsch--Gordan factors of an isobar node depend on which of its two children is
     listed first, and so does the isobar Wigner-:math:`d` function. The latter is
     constructed from `.get_decay_product_ids`, which follows the cyclic pair ordering
     :math:`(23)1, (31)2, (12)3` of `the DPD paper
-    <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.101.034033>`_ (Eq. 7), so the
-    node has to be brought into that same ordering before its Clebsch-Gordan factors are
-    formulated.
+    <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.101.034033>`_ (Eq. 7), so
+    the node has to be brought into that same ordering before its Clebsch--Gordan factors
+    are formulated.
     """
     child1 = to_particle(isobar.child1)
     if isinstance(child1, State) and child1.index == first_id:

--- a/tests/test_dpd_builder.py
+++ b/tests/test_dpd_builder.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import attrs
 import pytest
 import qrules
 import sympy as sp
 
 from ampform_dpd import AmplitudeModel, DalitzPlotDecompositionBuilder
 from ampform_dpd.adapter.qrules import normalize_state_ids, to_three_body_decay
+from ampform_dpd.decay import ThreeBodyDecay
 from ampform_dpd.dynamics.builder import formulate_breit_wigner_with_form_factor
 
 if TYPE_CHECKING:
@@ -177,6 +179,58 @@ class TestDalitzPlotDecompositionBuilder:
         n_coefficients = len(coefficients)
         assert n_coefficients == n_coupling_products
         assert n_coefficients == n_decay_couplings * n_production_couplings
+
+    def test_ls_amplitude_does_not_depend_on_child_order(
+        self, jpsi2pksigma_reaction: ReactionInfo
+    ):
+        """The subsystem amplitude may not depend on how a decay node is stored.
+
+        Which of the two children of an `.IsobarNode` is :attr:`~.IsobarNode.child1` is
+        an implementation detail of whoever constructed the `.ThreeBodyDecay`, but the
+        Clebsch-Gordan factors of the :math:`LS` basis and the isobar Wigner-:math:`d`
+        function both depend on the ordering of the decay products, so the two have to be
+        brought into the same ordering first.
+        """
+        if jpsi2pksigma_reaction.formalism == "helicity":
+            pytest.skip("Helicity formalism does not have LS couplings")
+        transitions = normalize_state_ids(jpsi2pksigma_reaction.transitions)
+        decay = to_three_body_decay(transitions, min_ls=True)
+        builders = [
+            DalitzPlotDecompositionBuilder(d, min_ls=False)
+            for d in (decay, _swap_decay_products(decay))
+        ]
+        helicities = (
+            sp.Integer(1),
+            sp.Integer(0),
+            sp.Rational(1, 2),
+            sp.Rational(-1, 2),
+        )
+        for subsystem_id in sorted({c.spectator.index for c in decay.chains}):
+            expressions = [
+                next(
+                    iter(
+                        b.formulate_subsystem_amplitude(
+                            *helicities,
+                            subsystem_id,
+                        ).amplitudes.values()
+                    )
+                ).doit()
+                for b in builders
+            ]
+            assert sp.simplify(expressions[0] - expressions[1]) == 0, subsystem_id
+
+
+def _swap_decay_products(decay: ThreeBodyDecay) -> ThreeBodyDecay:
+    """Reverse the order in which every decay node stores its two children."""
+    chains = []
+    for chain in decay.chains:
+        node = attrs.evolve(
+            chain.decay_node,
+            child1=chain.decay_node.child2,
+            child2=chain.decay_node.child1,
+        )
+        chains.append(attrs.evolve(chain, decay=attrs.evolve(chain.decay, child1=node)))
+    return ThreeBodyDecay(decay.states, chains)
 
 
 def _collect_indexed_symbols(amplitudes: list[sp.Expr]) -> set[sp.Indexed]:


### PR DESCRIPTION
Closes #202

## 🐛 Bug fixes

- The decay node is brought into the DPD cyclic pair ordering before its Clebsch-Gordan factors are formulated, so the $LS$ couplings and the isobar Wigner-d of that same node agree on which decay product comes first. The inline swap suggested in #202 is extracted into a documented `_order_decay_products` helper, which leaves one call site:

  ```python
  amplitude *= _formulate_clebsch_gordan_factors(
      isobar=_order_decay_products(chain.decay_node, first_id=i),
      helicities={...},
  )
  ```

- Of the two options in #202, this takes the one that fixes it in the builder: `to_three_body_decay` keeps sorting by final-state ID, so `ThreeBodyDecayChain.decay_products` — and therefore the dynamics builders and the serialization round-trip — stay untouched.

## ❗ Behavioral changes

- Affected models need a **refit**, not just a re-evaluation: the amplitude of every $LS$ model that populates subsystem&nbsp;2 shifts by a wave-dependent sign. Models in the helicity basis, and $LS$ models without a subsystem-2 chain, are unaffected.

## 🖱️ Developer experience

- `test_ls_amplitude_does_not_depend_on_child_order` states the invariant directly, rather than through the C-symmetry observable of #202: which of the two children an `IsobarNode` happens to store first is an implementation detail of whoever built the `ThreeBodyDecay`, so reversing it may not change the amplitude. The test builds each subsystem amplitude twice, once from the decay as `to_three_body_decay` produces it and once with every decay node's children reversed, and asserts that the two expressions are symbolically equal.

  Without the fix it fails on the subsystem whose ordering flips, with a relative sign:

  ```text
  A: -(sin(theta_12/2)/4 - 3*sin(3*theta_12/2)/4)*H[N(1700)+, 2, 1/2]*H[N(1700)+, 1, 1]/4
  B: +(sin(theta_12/2)/4 - 3*sin(3*theta_12/2)/4)*H[N(1700)+, 2, 1/2]*H[N(1700)+, 1, 1]/4
  ```

- **No existing test or notebook covered this**: the three `docs/comparison` notebooks that assert `DPD == AmpForm` all use `min_ls=True`, `docs/xib2pkk.ipynb` uses the $LS$ basis but only asserts non-NaN, and `docs/lc2pkpi.ipynb` uses `min_ls=(False, True)`, whose decay node is in the helicity basis and therefore unaffected. The whole suite passes unchanged either way, which is why this went unnoticed.