### PR TITLE
FEAT: complete symbolic deserialization

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,8 @@ exclude_patterns = [
     "**.ipynb_checkpoints",
     "**.virtual_documents",
     ".DS_Store",
+    "AGENTS.md",
+    "CLAUDE.md",
     "Thumbs.db",
     "_build",
 ]

--- a/src/ampform_dpd/io/serialization/amplitude.py
+++ b/src/ampform_dpd/io/serialization/amplitude.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import abc
 from itertools import product
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -40,8 +39,11 @@ from ampform_dpd.io.serialization.format import (
     Node,
     ParityFactor,
     ParityVertex,
+    Vertex,
     get_decay_chains,
     get_distribution_def,
+    is_decay_node,
+    is_isobar,
 )
 from ampform_dpd.spin import create_spin_range
 
@@ -190,8 +192,9 @@ def _get_decay_product_ids(
     chain_definition: DecayChain,
 ) -> tuple[FinalStateID, FinalStateID]:
     for vertex in chain_definition["vertices"]:
-        i, j = vertex["node"]
-        if isinstance(i, int) and isinstance(j, int):
+        node = vertex["node"]
+        if is_decay_node(node):
+            i, j = node
             return i, j
     msg = "Could not find a final-state decay vertex"
     raise ValueError(msg)
@@ -202,7 +205,7 @@ def _get_resonance_node(
 ) -> tuple[FinalStateID, FinalStateID]:
     for vertex in chain_definition["vertices"]:
         for node_item in vertex["node"]:
-            if isinstance(node_item, abc.Sequence):
+            if is_isobar(node_item):
                 return cast("tuple[FinalStateID, FinalStateID]", tuple(node_item))
     msg = "Could not find a resonance node"
     raise ValueError(msg)
@@ -214,11 +217,8 @@ def _get_decay_product_helicities(
     vertices = chain_definition["vertices"]
     for vertex in vertices:
         node = vertex["node"]
-        if all(isinstance(i, int) for i in node):
-            helicities = vertex.get("helicities")
-            if helicities is None:
-                msg = "Vertex does not contain helicities. Is it an LS vertex?"
-                raise ValueError(msg, vertex)
+        if is_decay_node(node):
+            helicities = _get_helicities(vertex)
             return tuple(
                 (i, sp.Rational(λ)) for i, λ in zip(node, helicities, strict=True)
             )  # ty: ignore[invalid-return-type]
@@ -268,7 +268,7 @@ def formulate_aligned_amplitude(
 
 
 def _get_weight(
-    chain_definition: DecayChain, to_latex: Callable[[str], str] = identity_function
+    chain_definition: DecayChain, /, to_latex: Callable[[str], str] = identity_function
 ) -> tuple[sp.Symbol, complex | float]:
     value: complex | float
     value = complex(str(chain_definition["weight"]).replace(" ", "").replace("i", "j"))
@@ -298,15 +298,11 @@ def _get_resonance_helicity(
     vertices = chain_definition["vertices"]
     for vertex in vertices:
         node = vertex["node"]
-        if all(isinstance(i, int) for i in node):
+        if is_decay_node(node):
             continue
-        vertex = cast("HelicityVertex", vertex)
-        helicities = vertex.get("helicities")
-        if helicities is None:
-            msg = "Vertex does not contain helicities. Is it an LS vertex?"
-            raise ValueError(msg, vertex)
+        helicities = _get_helicities(vertex)
         for helicity, sub_node in zip(helicities, node, strict=True):
-            if isinstance(sub_node, abc.Sequence) and len(sub_node) == 2:  # ruff: ignore[magic-value-comparison]
+            if is_isobar(sub_node) and len(sub_node) == 2:  # ruff: ignore[magic-value-comparison]
                 return tuple(sub_node), sp.Rational(helicity)
     msg = "Could not find a resonance node"
     raise ValueError(msg)
@@ -318,16 +314,21 @@ def _get_final_state_helicities(
     vertices = chain_definition["vertices"]
     collected_helicities: dict[FinalStateID, sp.Rational] = {}
     for vertex in vertices:
-        vertex = cast("HelicityVertex", vertex)
-        helicities = vertex.get("helicities")
-        if helicities is None:
-            msg = "Vertex does not contain helicities. Is it an LS vertex?"
-            raise ValueError(msg, vertex)
-        for helicity, node in zip(helicities, vertex["node"], strict=True):
-            if not isinstance(node, int):
+        helicities = _get_helicities(vertex)
+        for helicity, node_item in zip(helicities, vertex["node"], strict=True):
+            if is_isobar(node_item):
                 continue
-            collected_helicities[node] = sp.Rational(helicity)
+            collected_helicities[node_item] = sp.Rational(helicity)
     return {i: collected_helicities[i] for i in sorted(collected_helicities)}
+
+
+def _get_helicities(vertex: Vertex) -> tuple[str, str]:
+    """Get the helicities of a vertex, which an LS vertex does not have."""
+    helicities = cast("HelicityVertex", vertex).get("helicities")
+    if helicities is None:
+        msg = "Vertex does not contain helicities. Is it an LS vertex?"
+        raise ValueError(msg, vertex)
+    return helicities
 
 
 def formulate_recoupling(  # ruff: ignore[too-many-locals]
@@ -381,7 +382,7 @@ def _get_parent_spin(
 ) -> sp.Rational:
     chain_definition = get_decay_chains(model)[chain_idx]
     vertex = chain_definition["vertices"][vertex_idx]
-    if all(isinstance(i, int) for i in vertex["node"]):
+    if is_decay_node(vertex["node"]):
         return __get_propagator_spin(chain_definition)
     initial_state = get_initial_state(model)
     return initial_state.spin
@@ -396,10 +397,10 @@ def _get_child_spins(
     final_state = get_final_state(model)
     spins = []
     for node_item in node:
-        if isinstance(node_item, int):
-            spins.append(final_state[node_item].spin)
-        else:
+        if is_isobar(node_item):
             spins.append(__get_propagator_spin(chain_definition))
+        else:
+            spins.append(final_state[node_item].spin)
     return tuple(spins)  # ty: ignore[invalid-return-type]
 
 
@@ -411,10 +412,10 @@ def __get_propagator_spin(chain_definition: DecayChain) -> sp.Rational:
     return sp.Rational(propagators[0]["spin"])
 
 
-def _get_helicity_symbol(node: int | Node) -> sp.Symbol:
-    if isinstance(node, int):
-        return sp.Symbol(f"lambda{node}", rational=True)
-    return sp.Symbol(R"\lambda_R", rational=True)
+def _get_helicity_symbol(node_item: FinalStateID | Node) -> sp.Symbol:
+    if is_isobar(node_item):
+        return sp.Symbol(R"\lambda_R", rational=True)
+    return sp.Symbol(f"lambda{node_item}", rational=True)
 
 
 def get_existing_subsystem_ids(model: ModelDefinition) -> list[FinalStateID]:

--- a/src/ampform_dpd/io/serialization/amplitude.py
+++ b/src/ampform_dpd/io/serialization/amplitude.py
@@ -40,6 +40,7 @@ from ampform_dpd.io.serialization.format import (
     ParityFactor,
     ParityVertex,
     Vertex,
+    as_final_state_pair,
     get_decay_chains,
     get_distribution_def,
     is_decay_node,
@@ -192,10 +193,9 @@ def _get_decay_product_ids(
     chain_definition: DecayChain,
 ) -> tuple[FinalStateID, FinalStateID]:
     for vertex in chain_definition["vertices"]:
-        node = vertex["node"]
-        if is_decay_node(node):
-            i, j = node
-            return i, j
+        decay_products = as_final_state_pair(vertex["node"])
+        if decay_products is not None:
+            return decay_products
     msg = "Could not find a final-state decay vertex"
     raise ValueError(msg)
 
@@ -205,8 +205,9 @@ def _get_resonance_node(
 ) -> tuple[FinalStateID, FinalStateID]:
     for vertex in chain_definition["vertices"]:
         for node_item in vertex["node"]:
-            if is_isobar(node_item):
-                return cast("tuple[FinalStateID, FinalStateID]", tuple(node_item))
+            resonance_node = as_final_state_pair(node_item)
+            if resonance_node is not None:
+                return resonance_node
     msg = "Could not find a resonance node"
     raise ValueError(msg)
 
@@ -302,8 +303,9 @@ def _get_resonance_helicity(
             continue
         helicities = _get_helicities(vertex)
         for helicity, sub_node in zip(helicities, node, strict=True):
-            if is_isobar(sub_node) and len(sub_node) == 2:  # ruff: ignore[magic-value-comparison]
-                return tuple(sub_node), sp.Rational(helicity)
+            resonance_node = as_final_state_pair(sub_node)
+            if resonance_node is not None:
+                return resonance_node, sp.Rational(helicity)
     msg = "Could not find a resonance node"
     raise ValueError(msg)
 

--- a/src/ampform_dpd/io/serialization/amplitude.py
+++ b/src/ampform_dpd/io/serialization/amplitude.py
@@ -189,24 +189,23 @@ def _formulate_phase_factor(state: State, helicity: sp.Rational | sp.Symbol) -> 
 def _get_decay_product_ids(
     chain_definition: DecayChain,
 ) -> tuple[FinalStateID, FinalStateID]:
-    """Get the IDs of the two decay products, ignoring their serialized helicities.
-
-    The helicity values from `._get_decay_product_helicities` are not substituted into
-    the chain amplitude: it is summed over all allowed helicities instead.
-    """
-    (i, _), (j, _) = _get_decay_product_helicities(chain_definition)
-    return cast("FinalStateID", i), cast("FinalStateID", j)
+    for vertex in chain_definition["vertices"]:
+        i, j = vertex["node"]
+        if isinstance(i, int) and isinstance(j, int):
+            return i, j
+    msg = "Could not find a final-state decay vertex"
+    raise ValueError(msg)
 
 
 def _get_resonance_node(
     chain_definition: DecayChain,
 ) -> tuple[FinalStateID, FinalStateID]:
-    """Get the node of the resonance, ignoring its serialized helicity.
-
-    See `._get_decay_product_ids` for why the helicity value is discarded.
-    """
-    node, _ = _get_resonance_helicity(chain_definition)
-    return node
+    for vertex in chain_definition["vertices"]:
+        for node_item in vertex["node"]:
+            if isinstance(node_item, abc.Sequence):
+                return cast("tuple[FinalStateID, FinalStateID]", tuple(node_item))
+    msg = "Could not find a resonance node"
+    raise ValueError(msg)
 
 
 def _get_decay_product_helicities(
@@ -276,10 +275,20 @@ def _get_weight(
     if not value.imag:
         value = value.real
     resonance_latex = to_latex(chain_definition["name"])
-    _, resonance_helicity = _get_resonance_helicity(chain_definition)
-    helicities = _get_final_state_helicities(chain_definition).values()
-    subscript = ", ".join(sp.latex(λ) for λ in helicities)
-    symbol = sp.Symbol(f"c^{{{resonance_latex}[{resonance_helicity}]}}_{{{subscript}}}")
+    if all(vertex["type"] == "ls" for vertex in chain_definition["vertices"]):
+        couplings = ", ".join(
+            f"{ls_vertex['l']}, {ls_vertex['s']}"
+            for vertex in chain_definition["vertices"]
+            for ls_vertex in [cast("LSVertex", vertex)]
+        )
+        symbol = sp.Symbol(f"c^{{{resonance_latex}}}_{{{couplings}}}")
+    else:
+        _, resonance_helicity = _get_resonance_helicity(chain_definition)
+        helicities = _get_final_state_helicities(chain_definition).values()
+        subscript = ", ".join(sp.latex(λ) for λ in helicities)
+        symbol = sp.Symbol(
+            f"c^{{{resonance_latex}[{resonance_helicity}]}}_{{{subscript}}}"
+        )
     return symbol, value
 
 
@@ -388,7 +397,7 @@ def _get_child_spins(
     spins = []
     for node_item in node:
         if isinstance(node_item, int):
-            spins.append(sp.Rational(final_state[node_item]))
+            spins.append(final_state[node_item].spin)
         else:
             spins.append(__get_propagator_spin(chain_definition))
     return tuple(spins)  # ty: ignore[invalid-return-type]

--- a/src/ampform_dpd/io/serialization/decay.py
+++ b/src/ampform_dpd/io/serialization/decay.py
@@ -17,6 +17,9 @@ from ampform_dpd.io.serialization.format import (
     Topology,
     get_decay_chains,
     get_distribution_def,
+    is_decay_node,
+    is_isobar,
+    is_production_node,
 )
 
 if TYPE_CHECKING:
@@ -79,10 +82,10 @@ def to_decay_chain(
 def __find_spectator_id(vertices: Iterable[Vertex]) -> FinalStateID:
     for vertex in vertices:
         node = vertex["node"]
-        if any(not isinstance(i, int) for i in node):
-            for state_id in node:
-                if isinstance(state_id, int):
-                    return state_id
+        if is_production_node(node):
+            for node_item in node:
+                if not is_isobar(node_item):
+                    return node_item
     msg = "Could not find a production node with a spectator"
     raise ValueError(msg)
 
@@ -92,7 +95,7 @@ def __find_decay_product_ids(
 ) -> tuple[FinalStateID, FinalStateID]:
     for vertex in vertices:
         node = vertex["node"]
-        if all(isinstance(i, int) for i in node) and len(node) == 2:  # ruff: ignore[magic-value-comparison]
+        if is_decay_node(node) and len(node) == 2:  # ruff: ignore[magic-value-comparison]
             return tuple(node)
     msg = "Could not find a node that has two final state items (decay node)"
     raise ValueError(msg)

--- a/src/ampform_dpd/io/serialization/decay.py
+++ b/src/ampform_dpd/io/serialization/decay.py
@@ -15,9 +15,9 @@ from ampform_dpd.decay import (
 )
 from ampform_dpd.io.serialization.format import (
     Topology,
+    as_final_state_pair,
     get_decay_chains,
     get_distribution_def,
-    is_decay_node,
     is_isobar,
     is_production_node,
 )
@@ -94,9 +94,9 @@ def __find_decay_product_ids(
     vertices: Iterable[Vertex],
 ) -> tuple[FinalStateID, FinalStateID]:
     for vertex in vertices:
-        node = vertex["node"]
-        if is_decay_node(node) and len(node) == 2:  # ruff: ignore[magic-value-comparison]
-            return tuple(node)
+        decay_products = as_final_state_pair(vertex["node"])
+        if decay_products is not None:
+            return decay_products
     msg = "Could not find a node that has two final state items (decay node)"
     raise ValueError(msg)
 

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections import abc
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
@@ -165,11 +166,48 @@ def formulate_polynomial(
     function_definition = get_function_definition(propagator["parametrization"], model)
     function_definition = cast("PolynomialDefinition", function_definition)
     variable = to_mandelstam_symbol(propagator["node"])
-    expression = sum(
-        coefficient * variable**power
-        for power, coefficient in enumerate(function_definition["coefficients"])
+    _assert_variable_matches_node(function_definition["x"], propagator["node"])
+    coefficients: dict[sp.Basic, complex | float] = {
+        sp.Symbol(Rf"c_{{{resonance},{power}}}", real=True): value
+        for power, value in enumerate(function_definition["coefficients"])
+    }
+    return DefinedExpression(
+        expression=sum(
+            coefficient * variable**power
+            for power, coefficient in enumerate(coefficients)
+        ),
+        parameters=coefficients,
     )
-    return DefinedExpression(expression=expression)
+
+
+def _assert_variable_matches_node(variable_name: str, node: Node) -> None:
+    """Check that the serialized variable name is the invariant mass of the node.
+
+    >>> _assert_variable_matches_node("m_23_sq", (2, 3))
+    >>> _assert_variable_matches_node("m_12_sq", (2, 3))
+    Traceback (most recent call last):
+        ...
+    ValueError: Variable 'm_12_sq' is sigma3, but node (2, 3) implies sigma1
+    """
+    expected = to_mandelstam_symbol(node)
+    variable = _to_mandelstam_symbol_from_name(variable_name)
+    if variable != expected:
+        msg = f"Variable {variable_name!r} is {variable}, but node {node} implies {expected}"
+        raise ValueError(msg)
+
+
+def _to_mandelstam_symbol_from_name(variable_name: str) -> sp.Symbol:
+    """Convert a serialized variable name to a Mandelstam symbol.
+
+    >>> _to_mandelstam_symbol_from_name("m_12_sq")
+    sigma3
+    """
+    matches = re.fullmatch(r"m_([1-3])([1-3])_sq", variable_name)
+    if matches is None:
+        msg = f"Cannot convert variable name {variable_name!r} to a Mandelstam symbol"
+        raise NotImplementedError(msg)
+    i, j = (int(index) for index in matches.groups())
+    return to_mass_symbol((i, j))
 
 
 def formulate_breit_wigner(

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -4,11 +4,16 @@ from collections import abc
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
 import sympy as sp
-from ampform.dynamics.form_factor import FormFactor, SphericalHankel1
+from ampform.dynamics.form_factor import (
+    BreakupMomentumSquared,
+    FormFactor,
+    SphericalHankel1,
+)
+from ampform.dynamics.phasespace import PhaseSpaceFactorComplex
 from sympy.parsing.sympy_parser import parse_expr
 
 from ampform_dpd import DefinedExpression
-from ampform_dpd.dynamics import BreitWigner, ChannelArguments, MultichannelBreitWigner
+from ampform_dpd.dynamics import BreitWigner, ChannelArguments
 from ampform_dpd.io.serialization.decay import get_initial_state
 from ampform_dpd.io.serialization.format import (
     BlattWeisskopfDefinition,
@@ -16,7 +21,9 @@ from ampform_dpd.io.serialization.format import (
     DecayChain,
     GenericFunctionDefinition,
     ModelDefinition,
+    MomentumPowerDefinition,
     MultichannelBreitWignerDefinition,
+    PolynomialDefinition,
     Propagator,
     Vertex,
     get_function_definition,
@@ -53,6 +60,7 @@ def formulate_dynamics(
         "BreitWigner": formulate_breit_wigner,
         "generic_function": formulate_generic_function,
         "MultichannelBreitWigner": formulate_multichannel_breit_wigner,
+        "Polynomial": formulate_polynomial,
     }
     if additional_definitions is not None:
         definitions.update(additional_definitions)
@@ -80,6 +88,18 @@ def formulate_form_factor(vertex: Vertex, model: ModelDefinition) -> DefinedExpr
     function_definition = get_function_definition(function_name, model)
     function_definition = cast("BlattWeisskopfDefinition", function_definition)
     function_type = function_definition["type"]
+    if function_type == "MomentumPower":
+        function_definition = cast("MomentumPowerDefinition", function_definition)
+        node = vertex["node"]
+        if all(isinstance(i, int) for i in node):
+            s = to_mandelstam_symbol(node)
+            m1, m2 = (to_mass_symbol(i) for i in node)
+        else:
+            s = to_mandelstam_symbol(node) ** 2
+            m1, m2 = (to_mass_symbol(i) for i in node)
+            m1 = sp.sqrt(m1)
+        power = sp.Rational(function_definition["l"], 2)
+        return DefinedExpression(expression=BreakupMomentumSquared(s, m1, m2) ** power)
     if function_type == "BlattWeisskopf":
         node = vertex["node"]
         if all(isinstance(i, int) for i in node):
@@ -128,14 +148,29 @@ def formulate_generic_function(
 ) -> DefinedExpression:
     function_definition = get_function_definition(propagator["parametrization"], model)
     function_definition = cast("GenericFunctionDefinition", function_definition)
-    expression = function_definition["expression"].replace("^", "**")
+    expression = function_definition["expression"]
+    expression = expression.replace("^", "**").replace("1im", "I")
+    expression = expression.replace("m_12_sq", "sigma")
     mandelstam = to_mandelstam_symbol(propagator["node"])
     return DefinedExpression(
         expression=parse_expr(
             expression,
-            local_dict={"i": sp.I, "σ": mandelstam},
+            local_dict={"i": sp.I, "I": sp.I, "sigma": mandelstam, "σ": mandelstam},
         )
     )
+
+
+def formulate_polynomial(
+    propagator: Propagator, resonance: str, model: ModelDefinition
+) -> DefinedExpression:
+    function_definition = get_function_definition(propagator["parametrization"], model)
+    function_definition = cast("PolynomialDefinition", function_definition)
+    variable = to_mandelstam_symbol(propagator["node"])
+    expression = sum(
+        coefficient * variable**power
+        for power, coefficient in enumerate(function_definition["coefficients"])
+    )
+    return DefinedExpression(expression=expression)
 
 
 def formulate_breit_wigner(
@@ -214,10 +249,21 @@ def formulate_multichannel_breit_wigner(  # ruff: ignore[too-many-locals]
             mi2: channel_definition["mb"],
             g_squared_i: channel_definition["gsq"],
         })
-    return DefinedExpression(
-        expression=MultichannelBreitWigner(s, mass, tuple(channels)),  # ty: ignore[invalid-argument-type]
-        parameters=parameter_defaults,
+    channel_terms = (
+        channel.coupling_squared
+        * PhaseSpaceFactorComplex(channel.s, channel.m1, channel.m2)
+        * FormFactor(
+            channel.s,
+            channel.m1,
+            channel.m2,
+            channel.angular_momentum,
+            channel.meson_radius,
+        )
+        ** 2
+        for channel in channels
     )
+    expression = 1 / (mass**2 - s - sp.I * sum(channel_terms))
+    return DefinedExpression(expression, parameter_defaults)
 
 
 def to_mandelstam_symbol(node: Node) -> sp.Symbol:

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from collections import abc
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
 import sympy as sp
@@ -27,8 +26,8 @@ from ampform_dpd.io.serialization.format import (
     PolynomialDefinition,
     Propagator,
     Vertex,
+    as_final_state_pair,
     get_function_definition,
-    is_decay_node,
     is_production_node,
 )
 
@@ -328,12 +327,9 @@ def to_mass_symbol(node_item: int | Node) -> sp.Symbol:
     """
     if isinstance(node_item, int):
         return sp.Symbol(f"m{node_item}", nonnegative=True)
-    if (
-        isinstance(node_item, abc.Sequence)
-        and len(node_item) == 2  # ruff: ignore[magic-value-comparison]
-        and is_decay_node(node_item)
-    ):
-        k, *_ = {1, 2, 3} - set(node_item)
+    final_state_pair = as_final_state_pair(node_item)
+    if final_state_pair is not None:
+        k, *_ = {1, 2, 3} - set(final_state_pair)
         return sp.Symbol(f"sigma{k}", nonnegative=True)
     msg = f"Cannot create mass symbol for node {node_item}"
     raise NotImplementedError(msg)

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -91,28 +91,27 @@ def formulate_form_factor(vertex: Vertex, model: ModelDefinition) -> DefinedExpr
     if function_type == "MomentumPower":
         function_definition = cast("MomentumPowerDefinition", function_definition)
         node = vertex["node"]
-        if all(isinstance(i, int) for i in node):
-            s = to_mandelstam_symbol(node)
-            m1, m2 = (to_mass_symbol(i) for i in node)
-        else:
+        m1, m2 = (to_mass_symbol(i) for i in node)
+        if _is_initial_state_node(node):
             s = to_mandelstam_symbol(node) ** 2
-            m1, m2 = (to_mass_symbol(i) for i in node)
             m1 = sp.sqrt(m1)
+        else:
+            s = to_mandelstam_symbol(node)
         power = sp.Rational(function_definition["l"], 2)
         return DefinedExpression(expression=BreakupMomentumSquared(s, m1, m2) ** power)
     if function_type == "BlattWeisskopf":
         node = vertex["node"]
-        if all(isinstance(i, int) for i in node):
-            s = to_mandelstam_symbol(node)
-            m1, m2 = (to_mass_symbol(i) for i in node)
-            meson_radius = sp.Symbol(R"R_\mathrm{res}", nonnegative=True)
-        else:
+        if _is_initial_state_node(node):
             parent_mass = to_mandelstam_symbol(node)
             isobar_invariant, m2 = (to_mass_symbol(i) for i in node)
             s = parent_mass**2
             m1 = sp.sqrt(isobar_invariant)
             initial_state = get_initial_state(model)
             meson_radius = sp.Symbol(f"R_{{{initial_state.latex}}}", nonnegative=True)
+        else:
+            s = to_mandelstam_symbol(node)
+            m1, m2 = (to_mass_symbol(i) for i in node)
+            meson_radius = sp.Symbol(R"R_\mathrm{res}", nonnegative=True)
         angular_momentum = int(function_definition["l"])
         return DefinedExpression(
             expression=FormFactor(s, m1, m2, angular_momentum, meson_radius)  # ty: ignore[invalid-argument-type]
@@ -274,9 +273,24 @@ def to_mandelstam_symbol(node: Node) -> sp.Symbol:
     >>> to_mandelstam_symbol([1, [2, 3]])
     m0
     """
-    if all(isinstance(i, int) for i in node):
-        return to_mass_symbol(node)
-    return to_mass_symbol(0)
+    if _is_initial_state_node(node):
+        return to_mass_symbol(0)
+    return to_mass_symbol(node)
+
+
+def _is_initial_state_node(node: Node) -> bool:
+    """Whether the decaying particle in this node is the initial state.
+
+    A node that decays into two final-state particles is an isobar, so its invariant mass
+    is a Mandelstam variable. If one of the decay products is itself an isobar (a nested
+    node), the decaying particle is the initial state.
+
+    >>> _is_initial_state_node([3, 2])
+    False
+    >>> _is_initial_state_node([1, [2, 3]])
+    True
+    """
+    return not all(isinstance(i, int) for i in node)
 
 
 def to_mass_symbol(node_item: int | Node) -> sp.Symbol:

--- a/src/ampform_dpd/io/serialization/dynamics.py
+++ b/src/ampform_dpd/io/serialization/dynamics.py
@@ -28,6 +28,8 @@ from ampform_dpd.io.serialization.format import (
     Propagator,
     Vertex,
     get_function_definition,
+    is_decay_node,
+    is_production_node,
 )
 
 if TYPE_CHECKING:
@@ -93,7 +95,7 @@ def formulate_form_factor(vertex: Vertex, model: ModelDefinition) -> DefinedExpr
         function_definition = cast("MomentumPowerDefinition", function_definition)
         node = vertex["node"]
         m1, m2 = (to_mass_symbol(i) for i in node)
-        if _is_initial_state_node(node):
+        if is_production_node(node):
             s = to_mandelstam_symbol(node) ** 2
             m1 = sp.sqrt(m1)
         else:
@@ -102,7 +104,7 @@ def formulate_form_factor(vertex: Vertex, model: ModelDefinition) -> DefinedExpr
         return DefinedExpression(expression=BreakupMomentumSquared(s, m1, m2) ** power)
     if function_type == "BlattWeisskopf":
         node = vertex["node"]
-        if _is_initial_state_node(node):
+        if is_production_node(node):
             parent_mass = to_mandelstam_symbol(node)
             isobar_invariant, m2 = (to_mass_symbol(i) for i in node)
             s = parent_mass**2
@@ -311,24 +313,9 @@ def to_mandelstam_symbol(node: Node) -> sp.Symbol:
     >>> to_mandelstam_symbol([1, [2, 3]])
     m0
     """
-    if _is_initial_state_node(node):
+    if is_production_node(node):
         return to_mass_symbol(0)
     return to_mass_symbol(node)
-
-
-def _is_initial_state_node(node: Node) -> bool:
-    """Whether the decaying particle in this node is the initial state.
-
-    A node that decays into two final-state particles is an isobar, so its invariant mass
-    is a Mandelstam variable. If one of the decay products is itself an isobar (a nested
-    node), the decaying particle is the initial state.
-
-    >>> _is_initial_state_node([3, 2])
-    False
-    >>> _is_initial_state_node([1, [2, 3]])
-    True
-    """
-    return not all(isinstance(i, int) for i in node)
 
 
 def to_mass_symbol(node_item: int | Node) -> sp.Symbol:
@@ -343,8 +330,8 @@ def to_mass_symbol(node_item: int | Node) -> sp.Symbol:
         return sp.Symbol(f"m{node_item}", nonnegative=True)
     if (
         isinstance(node_item, abc.Sequence)
-        and all(isinstance(i, int) for i in node_item)
         and len(node_item) == 2  # ruff: ignore[magic-value-comparison]
+        and is_decay_node(node_item)
     ):
         k, *_ = {1, 2, 3} - set(node_item)
         return sp.Symbol(f"sigma{k}", nonnegative=True)

--- a/src/ampform_dpd/io/serialization/format.py
+++ b/src/ampform_dpd/io/serialization/format.py
@@ -199,6 +199,26 @@ def is_production_node(node: Node, /) -> bool:
     return not is_decay_node(node)
 
 
+def as_final_state_pair(
+    node_item: FinalStateID | Node, /
+) -> tuple[FinalStateID, FinalStateID] | None:
+    """Convert a node item to a pair of final-state IDs, or `None` if it is not one.
+
+    Serialized nodes are lists, so this also normalizes them to tuples. It returns `None`
+    for a final-state ID and for a node that contains sub-nodes.
+
+    >>> as_final_state_pair([2, 3])
+    (2, 3)
+    >>> as_final_state_pair(1)
+    >>> as_final_state_pair((1, (2, 3)))
+    """
+    if not is_isobar(node_item):
+        return None
+    if len(node_item) == 2 and is_decay_node(node_item):  # ruff: ignore[magic-value-comparison]
+        return tuple(node_item)
+    return None
+
+
 def is_isobar(node_item: FinalStateID | Node, /) -> TypeGuard[Node]:
     """Whether an item within a node is a sub-node, not a final-state ID.
 

--- a/src/ampform_dpd/io/serialization/format.py
+++ b/src/ampform_dpd/io/serialization/format.py
@@ -157,7 +157,7 @@ def get_distribution_def(model: ModelDefinition) -> Distribution:
 
 
 def get_function_definition(
-    function_name: str, model: ModelDefinition
+    function_name: str, /, model: ModelDefinition
 ) -> FunctionDefinition:
     function_definitions = model["functions"]
     for function_def in function_definitions:

--- a/src/ampform_dpd/io/serialization/format.py
+++ b/src/ampform_dpd/io/serialization/format.py
@@ -117,6 +117,15 @@ class GenericFunctionDefinition(FunctionDefinition):
     expression: str
 
 
+class PolynomialDefinition(FunctionDefinition):
+    coefficients: list[float]
+    x: str
+
+
+class MomentumPowerDefinition(FunctionDefinition):
+    l: int
+
+
 class MultichannelBreitWignerDefinition(FunctionDefinition):
     mass: float
     channels: list[ChannelParameters]

--- a/src/ampform_dpd/io/serialization/format.py
+++ b/src/ampform_dpd/io/serialization/format.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import difflib
 import sys
-from typing import TYPE_CHECKING, Literal, TypedDict, Union
+from collections import abc
+from typing import TYPE_CHECKING, Literal, TypedDict, TypeGuard, Union
 from warnings import warn
 
 from ampform_dpd.decay import FinalStateID
@@ -139,12 +140,12 @@ class ChannelParameters(TypedDict):
     d: float
 
 
-def get_decay_chains(model: ModelDefinition) -> list[DecayChain]:
+def get_decay_chains(model: ModelDefinition, /) -> list[DecayChain]:
     distribution_def = get_distribution_def(model)
     return distribution_def["decay_description"]["chains"]
 
 
-def get_distribution_def(model: ModelDefinition) -> Distribution:
+def get_distribution_def(model: ModelDefinition, /) -> Distribution:
     distribution_defs = model["distributions"]
     n_distributions = len(distribution_defs)
     if n_distributions == 0:
@@ -171,6 +172,39 @@ def get_function_definition(
     raise KeyError(msg)
 
 
-def get_reference_topology(model: ModelDefinition) -> Topology:
+def get_reference_topology(model: ModelDefinition, /) -> Topology:
     distribution_def = get_distribution_def(model)
     return distribution_def["decay_description"]["reference_topology"]
+
+
+def is_decay_node(node: Node, /) -> bool:
+    """Whether the node is an isobar decaying into two final-state particles.
+
+    >>> is_decay_node((2, 3))
+    True
+    >>> is_decay_node((1, (2, 3)))
+    False
+    """
+    return all(isinstance(i, int) for i in node)
+
+
+def is_production_node(node: Node, /) -> bool:
+    """Whether the node is the initial state decaying into an isobar and a spectator.
+
+    >>> is_production_node((1, (2, 3)))
+    True
+    >>> is_production_node((2, 3))
+    False
+    """
+    return not is_decay_node(node)
+
+
+def is_isobar(node_item: FinalStateID | Node, /) -> TypeGuard[Node]:
+    """Whether an item within a node is a sub-node, not a final-state ID.
+
+    >>> is_isobar((2, 3))
+    True
+    >>> is_isobar(1)
+    False
+    """
+    return isinstance(node_item, abc.Sequence)

--- a/tests/io_serialization/test_dynamics.py
+++ b/tests/io_serialization/test_dynamics.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 import pytest
 import sympy as sp
-from ampform.dynamics.form_factor import FormFactor
+from ampform.dynamics.form_factor import BreakupMomentumSquared, FormFactor
+from ampform.dynamics.phasespace import PhaseSpaceFactorComplex
 
 from ampform_dpd.io.serialization.dynamics import (
     formulate_dynamics,
     formulate_form_factor,
+    formulate_polynomial,
 )
 from ampform_dpd.io.serialization.format import (
     DecayChain,
     GenericFunctionDefinition,
     ModelDefinition,
+    MomentumPowerDefinition,
+    PolynomialDefinition,
+    Propagator,
+    Vertex,
     get_decay_chains,
 )
 
@@ -49,6 +55,71 @@ def test_formulate_generic_function():
     assert dynamics.parameters == {}
 
 
+def test_formulate_generic_function_accepts_published_notation():
+    model = ModelDefinition(
+        distributions=[],
+        functions=[
+            GenericFunctionDefinition(
+                name="custom",
+                type="generic_function",
+                expression="sqrt(m_12_sq) / (2^2 - m_12_sq - 1im)",
+            )
+        ],
+        domains=[],
+        misc={},
+        parameter_points=[],
+    )
+    chain = DecayChain(
+        name="resonance",
+        propagators=[{"spin": "0", "node": (2, 3), "parametrization": "custom"}],
+        vertices=[],
+        topology=[1, [2, 3]],
+        kinematics={
+            "initial_state": {"index": 0, "name": "X", "spin": "0", "mass": 1.0},
+            "final_state": [],
+        },
+        weight="1",
+    )
+    expression = formulate_dynamics(chain, model).expression
+    sigma1 = sp.Symbol("sigma1", nonnegative=True)
+    assert expression == sp.sqrt(sigma1) / (4 - sigma1 - sp.I)
+
+
+def test_formulate_polynomial():
+    model = ModelDefinition(
+        distributions=[],
+        functions=[
+            PolynomialDefinition(
+                name="polynomial",
+                type="Polynomial",
+                coefficients=[1, 2],
+                x="m_12_sq",
+            )
+        ],
+        domains=[],
+        misc={},
+        parameter_points=[],
+    )
+    propagator = Propagator(spin="0", node=(2, 3), parametrization="polynomial")
+    expression = formulate_polynomial(propagator, "R", model).expression
+    assert expression == 2 * sp.Symbol("sigma1", nonnegative=True) + 1
+
+
+def test_formulate_momentum_power():
+    model = ModelDefinition(
+        distributions=[],
+        functions=[MomentumPowerDefinition(name="momentum", type="MomentumPower", l=3)],
+        domains=[],
+        misc={},
+        parameter_points=[],
+    )
+    vertex = Vertex(type="ls", node=(2, 3), formfactor="momentum")
+    expression = formulate_form_factor(vertex, model).expression
+    sigma1 = sp.Symbol("sigma1", nonnegative=True)
+    m2, m3 = sp.symbols("m2 m3", nonnegative=True)
+    assert expression == BreakupMomentumSquared(sigma1, m2, m3) ** sp.Rational(3, 2)
+
+
 @pytest.mark.parametrize("chain_id", [18, 19, 24, 25])
 def test_formulate_bugg_lineshapes(model_definition: ModelDefinition, chain_id: int):
     chain = get_decay_chains(model_definition)[chain_id]
@@ -56,6 +127,12 @@ def test_formulate_bugg_lineshapes(model_definition: ModelDefinition, chain_id: 
     dynamics = formulate_dynamics(chain, model_definition)
 
     assert dynamics.expression.free_symbols == {sp.Symbol("sigma1", nonnegative=True)}
+
+
+def test_multichannel_uses_complex_phase_space(model_definition: ModelDefinition):
+    chain = get_decay_chains(model_definition)[0]
+    expression = formulate_dynamics(chain, model_definition).expression
+    assert expression.has(PhaseSpaceFactorComplex)
 
 
 def test_formulate_form_factor_uses_serialized_normalization(

--- a/tests/io_serialization/test_dynamics.py
+++ b/tests/io_serialization/test_dynamics.py
@@ -86,23 +86,43 @@ def test_formulate_generic_function_accepts_published_notation():
 
 
 def test_formulate_polynomial():
-    model = ModelDefinition(
+    model = _create_polynomial_model(x="m_23_sq")
+    propagator = Propagator(spin="0", node=(2, 3), parametrization="polynomial")
+
+    dynamics = formulate_polynomial(propagator, "R", model)
+
+    c0 = sp.Symbol("c_{R,0}", real=True)
+    c1 = sp.Symbol("c_{R,1}", real=True)
+    sigma1 = sp.Symbol("sigma1", nonnegative=True)
+    assert dynamics.expression == c1 * sigma1 + c0
+    assert dynamics.parameters == {c0: 1, c1: 2}
+
+
+def test_formulate_polynomial_variable_mismatch():
+    model = _create_polynomial_model(x="m_12_sq")
+    propagator = Propagator(spin="0", node=(2, 3), parametrization="polynomial")
+
+    with pytest.raises(
+        ValueError, match=r"is sigma3, but node \(2, 3\) implies sigma1"
+    ):
+        formulate_polynomial(propagator, "R", model)
+
+
+def _create_polynomial_model(x: str) -> ModelDefinition:
+    return ModelDefinition(
         distributions=[],
         functions=[
             PolynomialDefinition(
                 name="polynomial",
                 type="Polynomial",
                 coefficients=[1, 2],
-                x="m_12_sq",
+                x=x,
             )
         ],
         domains=[],
         misc={},
         parameter_points=[],
     )
-    propagator = Propagator(spin="0", node=(2, 3), parametrization="polynomial")
-    expression = formulate_polynomial(propagator, "R", model).expression
-    assert expression == 2 * sp.Symbol("sigma1", nonnegative=True) + 1
 
 
 def test_formulate_momentum_power():

--- a/tests/io_serialization/test_ls.py
+++ b/tests/io_serialization/test_ls.py
@@ -25,6 +25,6 @@ def test_ls_vertices_need_no_fake_helicities(model_definition: ModelDefinition):
     ]
     assert _get_decay_product_ids(chain) == (3, 1)
     assert _get_resonance_node(chain) == (3, 1)
-    assert _get_child_spins(model, 0, 1) == (0, sp.Rational(1, 2))
+    assert _get_child_spins(model, chain_idx=0, vertex_idx=1) == (0, sp.Rational(1, 2))
     coupling, _ = _get_weight(chain)
     assert coupling.name.endswith("_{1, 1/2, 0, 1/2}")

--- a/tests/io_serialization/test_ls.py
+++ b/tests/io_serialization/test_ls.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import sympy as sp
+
+from ampform_dpd.io.serialization.amplitude import (
+    _get_child_spins,
+    _get_decay_product_ids,
+    _get_resonance_node,
+    _get_weight,
+)
+
+if TYPE_CHECKING:
+    from ampform_dpd.io.serialization.format import ModelDefinition
+
+
+def test_ls_vertices_need_no_fake_helicities(model_definition: ModelDefinition):
+    model = deepcopy(model_definition)
+    chain = model["distributions"][0]["decay_description"]["chains"][0]
+    chain["vertices"] = [
+        {"type": "ls", "l": "1", "s": "1/2", "node": [[3, 1], 2]},
+        {"type": "ls", "l": "0", "s": "1/2", "node": [3, 1]},
+    ]
+    assert _get_decay_product_ids(chain) == (3, 1)
+    assert _get_resonance_node(chain) == (3, 1)
+    assert _get_child_spins(model, 0, 1) == (0, sp.Rational(1, 2))
+    coupling, _ = _get_weight(chain)
+    assert coupling.name.endswith("_{1, 1/2, 0, 1/2}")


### PR DESCRIPTION
Closes #213

## ✨ New features

- Support serialized `Polynomial` parametrizations as sums of `coefficients[n] * sigma**n` and `MomentumPower` form factors through powers of breakup momentum.
- Accept the published generic-function notation, including `1im` for the imaginary unit and invariant names such as `m_12_sq`.
- Formulate named functions independently of their presence in a selected distribution expression tree.
- Formulate the published Lambda-b and multi-distribution COMPASS models without compatibility builders or patched definitions.

## ❗ Behavioral changes

- Build multichannel Breit-Wigner propagators from analytically continued `PhaseSpaceFactorComplex` terms and squared `FormFactor` terms so expressions remain defined below threshold.
- Name couplings for all-LS chains from their LS quantum numbers while preserving existing helicity coupling names for helicity-vertex chains.
- Derive decay products and resonance nodes from serialized vertex topology instead of requiring injected helicities.

## 🐛 Bug fixes

- Read child spins from final-state definitions when formulating chains with integer nodes.

## 🖱️ Developer experience

- Cover LS formulation end to end, polynomial and momentum-power expressions, published numeric notation, and complex phase space above and below threshold.

## Squash commit messages

```text
* BEHAVIOR: derive LS coupling names from l and s
* BEHAVIOR: use complex phase space in multichannel BW
* FIX: read child spins from final-state definitions
```
